### PR TITLE
enhance Hostkey algorithms to SHA-2

### DIFF
--- a/lib/auth.ml
+++ b/lib/auth.ml
@@ -68,8 +68,5 @@ let by_pubkey name pubkey session_id service signed db =
   match lookup_user_key name pubkey db with
   | None -> false
   | Some pubkey ->
-    if pubkey = Hostkey.Unknown then
-      false
-    else
-      let unsigned = to_hash name pubkey session_id service in
-      Hostkey.verify pubkey ~unsigned ~signed
+    let unsigned = to_hash name pubkey session_id service in
+    Hostkey.verify pubkey ~unsigned ~signed

--- a/lib/client.ml
+++ b/lib/client.ml
@@ -43,7 +43,7 @@ type state =
   | Newkeys_before_auth of Kex.keys * Kex.keys
   | Requested_service of string
   | Userauth_request of Ssh.auth_method
-  | Userauth_requested
+  | Userauth_requested of Hostkey.pub option
   | Opening_channel of Channel.channel_end
   | Established
 
@@ -55,6 +55,7 @@ type t = {
   keying         : bool;
   key_eol        : Mtime.t option;
   channels       : Channel.db;
+  sig_algs : Hostkey.alg list ;
   linger  : Cstruct.t;
   user : string ;
   key : Hostkey.priv ;
@@ -114,6 +115,7 @@ let make ?(authenticator = `No_authentication) ~user key =
             key_eol = None;
             linger = Cstruct.empty;
             channels = Channel.empty_db;
+            sig_algs = [];
             user ; key ; authenticator
           }
   in
@@ -131,7 +133,19 @@ let handle_kexinit t c_v ckex s_v skex =
       Kex (Negotiated_kex (c_v, ckex, s_v, skex, neg, secret, my_pub)),
       Ssh.Msg_kexdh_init my_pub
   in
-  ok ({ t with state }, [ msg ], [])
+  (* this is not correct in respect to the specification (should use
+     server-sig-algs extension of 8308): we reuse the server host key algorithms
+     from the kex for client key authentication. we iterate over them on
+     failure -> eventually we'll use ssh-rsa if the server denies sha256/512 *)
+  let sig_algs =
+    let s =
+      List.fold_left (fun acc a ->
+          match Hostkey.alg_of_string a with Ok a -> a :: acc | Error _ -> acc)
+        [] skex.server_host_key_algs
+    in
+    List.filter (fun a -> List.mem a s) Hostkey.preferred_algs
+  in
+  ok ({ t with state ; sig_algs }, [ msg ], [])
 
 let handle_kexdh_reply t now v_c ckex v_s skex neg secret my_pub k_s theirs (alg, signed) =
   Kex.Dh.shared secret theirs >>= fun shared ->
@@ -208,16 +222,19 @@ let handle_auth_failure t _ = function
         [])
   | _ -> Error "no supported authentication methods left"
 
+let handle_pk_auth t pk =
+  let session_id = match t.session_id with None -> assert false | Some x -> x in
+  (match t.sig_algs with
+   | [] -> Error "no more signature algorithms available"
+   | a :: rt -> Ok (a, rt)) >>= fun (alg, sig_algs) ->
+  let signed = Auth.sign t.user alg t.key session_id service in
+  let met = Ssh.Pubkey (Hostkey.pub_of_priv t.key, Some (alg, signed)) in
+  Ok ({ t with state = Userauth_requested (Some pk) ; sig_algs },
+      [ Ssh.Msg_userauth_request (t.user, service, met) ],
+      [])
+
 let handle_pk_ok t m pk = match m with
-  | Ssh.Pubkey (pub, None) when pub = pk ->
-    let session_id = match t.session_id with None -> assert false | Some x -> x in
-    (* TODO figure out which to use from extensions, RFC 8308 *)
-    let alg = Hostkey.Rsa_sha1 in
-    let signed = Auth.sign t.user alg t.key session_id service in
-    let met = Ssh.Pubkey (Hostkey.pub_of_priv t.key, Some (alg, signed)) in
-    Ok ({ t with state = Userauth_requested },
-        [ Ssh.Msg_userauth_request (t.user, service, met) ],
-        [])
+  | Ssh.Pubkey (pub, None) when pub = pk -> handle_pk_auth t pk
   | _ -> Error "not sure how we ended in pk ok now"
 
 let open_channel t =
@@ -280,8 +297,9 @@ let input_msg t msg now =
   | Userauth_request m, Msg_userauth_failure (methods, _) ->
     handle_auth_failure t m methods
   | Userauth_request m, Msg_userauth_pk_ok pk -> handle_pk_ok t m pk
+  | Userauth_requested (Some pk), Msg_userauth_failure _ -> handle_pk_auth t pk
   | Userauth_request _, Msg_userauth_success -> open_channel t
-  | Userauth_requested, Msg_userauth_success -> open_channel t
+  | Userauth_requested _, Msg_userauth_success -> open_channel t
   | Opening_channel us, Msg_channel_open_confirmation (oid, tid, win, max, data) ->
     open_channel_success t us oid tid win max data
   | _, Msg_global_request (_, want_reply, Unknown_request _) ->

--- a/lib/hostkey.ml
+++ b/lib/hostkey.ml
@@ -62,7 +62,7 @@ let alg_of_sexp = function
 
 let sexp_of_alg t = Sexplib.Sexp.Atom (alg_to_string t)
 
-let preferred_algs = [ Rsa_sha256 ; Rsa_sha256 ; Rsa_sha1 ]
+let preferred_algs = [ Rsa_sha256 ; Rsa_sha512 ; Rsa_sha1 ]
 
 let signature_equal = Cstruct.equal
 

--- a/lib/hostkey.ml
+++ b/lib/hostkey.ml
@@ -21,7 +21,6 @@ type priv =
 
 type pub =
   | Rsa_pub of Rsa.pub
-  | Unknown
 
 let pub_of_priv = function
   | Rsa_priv priv -> Rsa_pub (Rsa.pub_of_priv priv)
@@ -31,7 +30,6 @@ let pub_of_sexp _ = failwith "Hostkey.pub_of_sexp: TODO"
 
 let sshname = function
   | Rsa_pub _ -> "ssh-rsa"
-  | Unknown -> "unknown"
 
 let signature_equal = Cstruct.equal
 
@@ -42,7 +40,6 @@ let sign priv blob =
 
 let verify pub ~unsigned ~signed =
   match pub with
-  | Unknown -> false
   | Rsa_pub pub ->
     let hashp = function `SHA1 -> true | _ -> false in
     Rsa.PKCS1.verify ~hashp ~key:pub ~signature:signed (`Message unsigned)

--- a/lib/keys.ml
+++ b/lib/keys.ml
@@ -8,7 +8,6 @@ type authenticator = [
 ]
 
 let hostkey_matches a = function
-  | Hostkey.Unknown -> false
   | Hostkey.Rsa_pub pub ->
     let hash = Mirage_crypto.Hash.SHA256.digest (Wire.blob_of_pubkey (Hostkey.Rsa_pub pub))  in
     Logs.app (fun m -> m "authenticating RSA server fingerprint SHA256:%s"
@@ -49,8 +48,7 @@ let authenticator_of_string str =
       match Base64.decode ~pad:false str with
       | Ok k ->
         (Wire.pubkey_of_blob (Cstruct.of_string k) >>= function
-          | Hostkey.Rsa_pub key -> Ok (`Key key)
-          | Hostkey.Unknown -> Error "invalid authenticator")
+          | Hostkey.Rsa_pub key -> Ok (`Key key))
       | Error (`Msg msg) ->
         Error (str ^ " is invalid or unsupported authenticator, b64 failed: " ^ msg)
 

--- a/lib/server.ml
+++ b/lib/server.ml
@@ -160,10 +160,7 @@ let rec input_userauth_request t username service auth_method =
     make_reply { t with auth_state = Done; expect = None } Msg_userauth_success
   in
   let try_probe t pubkey =
-    if pubkey <> Hostkey.Unknown then
-      make_reply t (Msg_userauth_pk_ok pubkey)
-    else
-      failure t
+    make_reply t (Msg_userauth_pk_ok pubkey)
   in
   let try_auth t b = if b then success t else failure t in
   let handle_auth t =

--- a/lib/server.ml
+++ b/lib/server.ml
@@ -170,8 +170,8 @@ let rec input_userauth_request t username service auth_method =
     match auth_method with
     | Pubkey (pubkey, None) ->        (* Public key probing *)
       try_probe t pubkey
-    | Pubkey (pubkey, Some signed) -> (* Public key authentication *)
-      try_auth t (by_pubkey username pubkey session_id service signed t.user_db)
+    | Pubkey (pubkey, Some (alg, signed)) -> (* Public key authentication *)
+      try_auth t (by_pubkey username alg pubkey session_id service signed t.user_db)
     | Password (password, None) ->    (* Password authentication *)
       try_auth t (by_password username password t.user_db)
     (* Change of password, or Hostbased or Authnone won't be supported *)
@@ -320,13 +320,14 @@ let input_msg t msg now =
             ~k_s:pub_host_key
             ~e ~f ~k
         in
-        let signature = Hostkey.sign t.host_key h in
+        let signature = Hostkey.sign neg.server_host_key_alg t.host_key h in
         Format.printf "shared is %a signature is %a (hash %a)\n%!"
           Cstruct.hexdump_pp (Mirage_crypto_pk.Z_extra.to_cstruct_be f)
           Cstruct.hexdump_pp signature Cstruct.hexdump_pp h;
         let session_id = match t.session_id with None -> h | Some x -> x in
         Kex.Dh.derive_keys k h session_id neg now
         >>= fun (new_keys_ctos, new_keys_stoc, key_eol) ->
+        let signature = neg.server_host_key_alg, signature in
         make_replies { t with session_id = Some session_id;
                               new_keys_ctos = Some new_keys_ctos;
                               new_keys_stoc = Some new_keys_stoc;

--- a/lib/ssh.ml
+++ b/lib/ssh.ml
@@ -170,7 +170,7 @@ let sexp_of_password _ = sexp_of_string "????"
 let password_of_sexp _ = failwith "password_of_sexp: TODO"
 
 type auth_method =
-  | Pubkey of (Hostkey.pub * Cstruct_sexp.t option)
+  | Pubkey of (Hostkey.pub * (Hostkey.alg * Cstruct_sexp.t) option)
   | Password of (password * password option)
   | Hostbased of (string * Cstruct_sexp.t * string * string * Cstruct_sexp.t) (* TODO *)
   | Authnone
@@ -181,7 +181,7 @@ let auth_method_equal a b =
   | Pubkey (key_a, signature_a),
     Pubkey (key_b, signature_b) ->
     let signature_match = match signature_a, signature_b with
-      | Some sa, Some sb -> Cstruct.equal sa sb
+      | Some (alga, sa), Some (algb, sb) -> alga = algb && Cstruct.equal sa sb
       | None, None -> true
       | _ -> false
     in
@@ -204,14 +204,14 @@ type message =
   | Msg_service_accept of string
   | Msg_kexinit of kexinit
   | Msg_newkeys
-  | Msg_kexdh_reply of (Hostkey.pub * mpint * Cstruct_sexp.t)
+  | Msg_kexdh_reply of Hostkey.pub * mpint * (Hostkey.alg * Cstruct_sexp.t)
   | Msg_kexdh_init of mpint
   (* from RFC 4419 *)
   (* there's as well a Msg_kexdh_gex_request_old with only a single int32 *)
   | Msg_kexdh_gex_request of int32 * int32 * int32
   | Msg_kexdh_gex_group of mpint * mpint
   | Msg_kexdh_gex_init of mpint
-  | Msg_kexdh_gex_reply of Hostkey.pub * mpint * Cstruct_sexp.t
+  | Msg_kexdh_gex_reply of Hostkey.pub * mpint * (Hostkey.alg * Cstruct_sexp.t)
   | Msg_kex of message_id * Cstruct_sexp.t
   | Msg_userauth_request of (string * string * auth_method)
   | Msg_userauth_failure of (string list * bool)


### PR DESCRIPTION
client authentication with RSA keys still use SHA1, since RFC 8308 (extensions) need to be implemented before SHA-2 algorithms can be used.