### PR TITLE
store sequence number in Kex.keys instead of in Hmac.hmac

### DIFF
--- a/lib/client.ml
+++ b/lib/client.ml
@@ -66,14 +66,12 @@ let established t = match t.state with Established -> true | _ -> false
 
 let rotate_keys_ctos t new_keys_ctos =
   let open Kex in
-  let new_mac_ctos = { new_keys_ctos.mac with seq = t.keys_ctos.mac.seq } in
-  let new_keys_ctos = { new_keys_ctos with mac = new_mac_ctos } in
+  let new_keys_ctos = { new_keys_ctos with seq = t.keys_ctos.seq } in
   { t with keys_ctos = new_keys_ctos }
 
 let rotate_keys_stoc t new_keys_stoc =
   let open Kex in
-  let new_mac_stoc = { new_keys_stoc.mac with seq = t.keys_stoc.mac.seq } in
-  let new_keys_stoc = { new_keys_stoc with mac = new_mac_stoc } in
+  let new_keys_stoc = { new_keys_stoc with seq = t.keys_stoc.seq } in
   { t with keys_stoc = new_keys_stoc; keying = false }
 
 let debug_msg prefix = function

--- a/lib/hmac.ml
+++ b/lib/hmac.ml
@@ -30,7 +30,6 @@ type t =
 type key = {
   hmac : t;            (* Hmac algorithm *)
   key  : Cstruct.t;    (* The actual hmac key *)
-  seq  : int32;        (* Sequence number for hmac *)
 }
 
 let to_string = function

--- a/lib/kex.ml
+++ b/lib/kex.ml
@@ -198,6 +198,7 @@ let negotiate ~s ~c =
 type keys = {
   cipher   : Cipher.key; (* Encryption key *)
   mac      : Hmac.key;   (* Integrity key *)
+  seq      : int32;      (* Sequence number *)
   tx_rx    : int64;      (* Transmitted or Received bytes with this key *)
 }
 
@@ -205,8 +206,8 @@ let make_plaintext () =
   { cipher = Cipher.{ cipher = Plaintext;
                       cipher_key = Plaintext_key };
     mac = Hmac.{ hmac = Plaintext;
-                 key = Cstruct.create 0;
-                 seq = Int32.zero };
+                 key = Cstruct.create 0 };
+    seq = Int32.zero ;
     tx_rx = Int64.zero }
 
 let is_plaintext keys =
@@ -270,8 +271,8 @@ let derive_keys digesti k h session_id neg now =
   let ctos = { cipher = hash 'C' (Cipher.key_len cipher_ctos) |>
                         key_of cipher_ctos ctos_iv;
                mac = Hmac.{ hmac = mac_ctos;
-                            key = hash 'E' (key_len mac_ctos);
-                            seq = Int32.zero };
+                            key = hash 'E' (key_len mac_ctos) };
+               seq = Int32.zero;
                tx_rx = Int64.zero }
   in
   (* Build new stoc keys *)
@@ -279,8 +280,8 @@ let derive_keys digesti k h session_id neg now =
   let stoc = { cipher = hash 'D' (Cipher.key_len cipher_stoc) |>
                         key_of cipher_stoc stoc_iv;
                mac = Hmac.{ hmac = mac_stoc;
-                            key = hash 'F' (key_len mac_stoc);
-                            seq = Int32.zero };
+                            key = hash 'F' (key_len mac_stoc) };
+               seq = Int32.zero;
                tx_rx = Int64.zero }
   in
   guard_some (Mtime.add_span now keys_lifespan) "key eol overflow"

--- a/lib/server.ml
+++ b/lib/server.ml
@@ -83,21 +83,17 @@ let make host_key user_db =
 (* t with updated keys from new_keys_ctos *)
 let of_new_keys_ctos t =
   let open Kex in
-  let open Hmac in
   guard_some t.new_keys_ctos "No new_keys_ctos" >>= fun new_keys_ctos ->
   guard (is_keyed new_keys_ctos) "Plaintext new keys" >>= fun () ->
-  let new_mac_ctos = { new_keys_ctos.mac with seq = t.keys_ctos.mac.seq } in
-  let new_keys_ctos = { new_keys_ctos with mac = new_mac_ctos } in
+  let new_keys_ctos = { new_keys_ctos with seq = t.keys_ctos.seq } in
   ok { t with keys_ctos = new_keys_ctos; new_keys_ctos = None }
 
 (* t with updated keys from new_keys_stoc *)
 let of_new_keys_stoc t =
   let open Kex in
-  let open Hmac in
   guard_some t.new_keys_stoc "No new_keys_stoc" >>= fun new_keys_stoc ->
   guard (is_keyed new_keys_stoc) "Plaintext new keys" >>= fun () ->
-  let new_mac_stoc = { new_keys_stoc.mac with seq = t.keys_stoc.mac.seq } in
-  let new_keys_stoc = { new_keys_stoc with mac = new_mac_stoc } in
+  let new_keys_stoc = { new_keys_stoc with seq = t.keys_stoc.seq } in
   ok { t with keys_stoc = new_keys_stoc; new_keys_stoc = None; keying = false }
 
 let rekey t =

--- a/test/test.ml
+++ b/test/test.ml
@@ -53,7 +53,7 @@ let cipher_key_of cipher key iv =
     { cipher;
       cipher_key = Aes_cbc_key ((CBC.of_secret key), iv) }
 
-let hmac_key_of hmac key = Hmac.{ hmac; key; seq = Int32.zero }
+let hmac_key_of hmac key = Hmac.{ hmac; key }
 
 let encrypt_plain msg =
   fst (Packet.encrypt (Kex.make_plaintext ()) msg)
@@ -374,7 +374,7 @@ let t_crypto () =
     let iv = Cstruct.sub secret 0 16 in
     let cipher = cipher_key_of cipher secret iv in
     let mac = hmac_key_of hmac secret in
-    Kex.{ cipher; mac; tx_rx = Int64.zero }
+    Kex.{ cipher; mac; seq = Int32.zero; tx_rx = Int64.zero }
   in
   List.iter (fun cipher ->
       List.iter (fun hmac ->


### PR DESCRIPTION
this refactoring simplifies extensions of AEAD ciphers which do not use a hmac,
but still use the sequence number for authentication