### PR TITLE
Chacha20/poly1305 support

### DIFF
--- a/awa.opam
+++ b/awa.opam
@@ -18,7 +18,7 @@ depends: [
   "dune" {>= "1.0"}
   "ppx_sexp_conv"
   "ppx_cstruct"
-  "mirage-crypto"
+  "mirage-crypto" {>= "0.8.1"}
   "mirage-crypto-rng"
   "mirage-crypto-pk"
   "x509" {>= "0.10.0"}

--- a/lib/cipher.ml
+++ b/lib/cipher.ml
@@ -25,11 +25,17 @@ type t =
   | Aes128_cbc
   | Aes192_cbc
   | Aes256_cbc
+  | Chacha20_poly1305
+
+let aead = function
+  | Chacha20_poly1305 -> true
+  | _ -> false
 
 type cipher_key =
   | Plaintext_key
-  | Aes_ctr_key of (CTR.key * Mirage_crypto.Cipher_block.AES.CTR.ctr)
+  | Aes_ctr_key of (CTR.key * CTR.ctr)
   | Aes_cbc_key of (CBC.key * Cstruct.t)
+  | Chacha20_poly1305_key of (Mirage_crypto.Chacha20.key * Mirage_crypto.Chacha20.key)
 
 type key = {
   cipher     : t;
@@ -44,6 +50,7 @@ let to_string = function
   | Aes128_cbc -> "aes128-cbc"
   | Aes192_cbc -> "aes192-cbc"
   | Aes256_cbc -> "aes256-cbc"
+  | Chacha20_poly1305 -> "chacha20-poly1305@openssh.com"
 
 let of_string = function
   | "none"       -> ok Plaintext
@@ -53,6 +60,7 @@ let of_string = function
   | "aes128-cbc" -> ok Aes128_cbc
   | "aes192-cbc" -> ok Aes192_cbc
   | "aes256-cbc" -> ok Aes256_cbc
+  | "chacha20-poly1305@openssh.com" -> ok Chacha20_poly1305
   | s -> error ("Unknown cipher " ^ s)
 
 let key_len = function
@@ -63,41 +71,87 @@ let key_len = function
   | Aes128_cbc -> 16
   | Aes192_cbc -> 24
   | Aes256_cbc -> 32
+  | Chacha20_poly1305 -> 64
 
 let iv_len = function
   | Plaintext -> 0
   | Aes128_ctr | Aes192_ctr | Aes256_ctr -> CTR.block_size
   | Aes128_cbc | Aes192_cbc | Aes256_cbc -> CBC.block_size
+  | Chacha20_poly1305 -> 0
 
 let block_len = function
   | Plaintext -> 8
   | Aes128_ctr | Aes192_ctr | Aes256_ctr -> CTR.block_size
   | Aes128_cbc | Aes192_cbc | Aes256_cbc -> CBC.block_size
+  | Chacha20_poly1305 -> 8
+
+let mac_len = function
+  | Chacha20_poly1305 -> Mirage_crypto.Poly1305.mac_size
+  | _ -> 0
 
 let known s = is_ok (of_string s)
 
 (* For some reason Nocrypto CTR modifies ctr in place, CBC returns next *)
-let enc_dec enc cipher buf =
+let enc_dec enc ~len seq cipher buf =
   let open Mirage_crypto.Cipher_block in
   match cipher.cipher_key with
-  | Plaintext_key -> buf, cipher
+  | Plaintext_key -> ok (buf, cipher)
   | Aes_ctr_key (key, iv) ->
     let f = if enc then AES.CTR.encrypt else AES.CTR.decrypt in
     let buf = f ~key ~ctr:iv buf in
     let next_iv = AES.CTR.next_ctr ~ctr:iv buf in
     let cipher_key = Aes_ctr_key (key, next_iv) in
     let key = { cipher with cipher_key } in
-    buf, key
+    ok (buf, key)
   | Aes_cbc_key (key, iv) ->
     let f = if enc then AES.CBC.encrypt else AES.CBC.decrypt in
     let buf = f ~key ~iv buf in
     let next_iv = AES.CBC.next_iv ~iv buf in
     let cipher_key = Aes_cbc_key (key, next_iv) in
     let cipher = { cipher with cipher_key } in
-    buf, cipher
+    ok (buf, cipher)
+  | Chacha20_poly1305_key (len_key, key) ->
+    let nonce =
+      let b = Cstruct.create 8 in
+      Cstruct.BE.set_uint64 b 0 (Int64.of_int32 seq);
+      b
+    in
+    let c_len b = Mirage_crypto.Chacha20.crypt ~key:len_key ~nonce b in
+    let c_data b = Mirage_crypto.Chacha20.crypt ~key ~ctr:1L ~nonce b in
+    let mac data =
+      let key = Mirage_crypto.Chacha20.crypt ~key ~nonce (Cstruct.create 32) in
+      Mirage_crypto.Poly1305.mac ~key data
+    in
+    if enc then
+      let lbuf, msg = Cstruct.split buf 4 in
+      let enc_len = c_len lbuf in
+      let enc_msg = c_data msg in
+      let out = Cstruct.append enc_len enc_msg in
+      let tag = mac out in
+      ok (Cstruct.append out tag, cipher)
+    else
+      begin
+        if len then
+          ok (c_len buf, cipher)
+        else
+          let c, tag = Cstruct.split buf (Cstruct.len buf - Mirage_crypto.Poly1305.mac_size) in
+          let ctag = mac c in
+          let enc_len, enc_msg = Cstruct.split c 4 in
+          let dec_len = c_len enc_len
+          and dec_msg = c_data enc_msg
+          in
+          if Cstruct.equal ctag tag then
+            ok (Cstruct.append dec_len dec_msg, cipher)
+          else
+            error "tag verification failed"
+      end
 
-let encrypt = enc_dec true
+let encrypt ~len seq cipher buf =
+  match enc_dec true ~len seq cipher buf with
+  | Ok a -> a
+  | Error _ -> assert false
 let decrypt = enc_dec false
 
-let preferred = [ Aes128_ctr; Aes192_ctr; Aes256_ctr;
+let preferred = [ Chacha20_poly1305 ;
+                  Aes128_ctr; Aes192_ctr; Aes256_ctr;
                   Aes128_cbc; Aes192_cbc; Aes256_cbc; ]

--- a/lib/client.ml
+++ b/lib/client.ml
@@ -121,6 +121,7 @@ let make ?(authenticator = `No_authentication) ~user key =
 
 let handle_kexinit t c_v ckex s_v skex =
   Kex.negotiate ~s:skex ~c:ckex >>= fun neg ->
+  Log.info (fun m -> m "negotiated: %a" Kex.pp_negotiation neg);
   (* two cases: directly send the kexdh_init, or RFC 4419 and negotiate group *)
   let state, msg =
     if Kex.is_rfc4419 neg.kex_alg then

--- a/lib/packet.ml
+++ b/lib/packet.ml
@@ -24,10 +24,10 @@ let hmac mac seq buf =
   Cstruct.BE.set_uint32 seqbuf 0 seq;
   Hmac.hmacv hmac ~key [ seqbuf; buf ]
 
-let peek_len cipher block_len buf =
+let peek_len cipher seq block_len buf =
   assert (block_len <= Cstruct.len buf);
   let buf = Cstruct.sub buf 0 block_len in
-  let hdr, _ = Cipher.decrypt cipher buf in
+  Cipher.decrypt ~len:true seq cipher buf >>| fun (hdr, _) ->
   Ssh.get_pkt_hdr_pkt_len hdr |> Int32.to_int
 
 let partial buf =
@@ -43,39 +43,44 @@ let decrypt keys buf =
   let open Ssh in
   let cipher = keys.Kex.cipher in
   let mac = keys.Kex.mac in
+  let seq = keys.Kex.seq in
   let block_len = max 8 (Cipher.block_len cipher.Cipher.cipher) in
-  let digest_len = Hmac.(digest_len mac.hmac) in
-  if Cstruct.len buf < max sizeof_pkt_hdr (digest_len + block_len) then
+  let digest_len = Hmac.(digest_len mac.hmac)
+  and mac_len = Cipher.(mac_len cipher.Cipher.cipher)
+  in
+  if Cstruct.len buf < max sizeof_pkt_hdr (digest_len + mac_len + block_len) then
     partial buf
   else
-    let pkt_len = peek_len cipher block_len buf in
+    peek_len cipher seq block_len buf >>= fun pkt_len ->
     guard (pkt_len > 0 && pkt_len < max_pkt_len) "decrypt: Bogus pkt len"
     >>= fun () ->
     (* 4 is pkt_len field itself *)
     if Cstruct.len buf < pkt_len + 4 + digest_len then
       partial buf
     else
-      let pkt_enc, digest1 = Cstruct.split buf (pkt_len + 4) in
-      let tx_rx = Int64.(add keys.Kex.tx_rx (Cstruct.len pkt_enc |> of_int)) in
-      let pkt_dec, cipher = Cipher.decrypt cipher pkt_enc in
+      let pkt_enc, digest1 = Cstruct.split buf (pkt_len + 4 + mac_len) in
+      let tx_rx = Int64.(add keys.Kex.tx_rx (Cstruct.len pkt_enc - mac_len |> of_int)) in
+      Cipher.decrypt ~len:false seq cipher pkt_enc >>= fun (pkt_dec, cipher) ->
       let digest1 = Cstruct.sub digest1 0 digest_len in
-      let digest2 = hmac mac keys.Kex.seq pkt_dec in
+      let digest2 = hmac mac seq pkt_dec in
       guard (Cstruct.equal digest1 digest2)
         "decrypt: Bad digest" >>= fun () ->
       let pad_len = get_pkt_hdr_pad_len pkt_dec in
       guard (pad_len >= 4 && pad_len <= 255 && pad_len < pkt_len)
         "decrypt: Bogus pad len"  >>= fun () ->
-      let buf = Cstruct.shift buf (4 + pkt_len + digest_len) in
+      let buf = Cstruct.shift buf (4 + pkt_len + mac_len + digest_len) in
       let keys = Kex.{ cipher; mac; seq = Int32.succ keys.Kex.seq; tx_rx } in
       ok (Some (pkt_dec, buf, keys))
 
 let encrypt keys msg =
   let cipher = keys.Kex.cipher in
   let mac = keys.Kex.mac in
+  let seq = keys.Kex.seq in
   let block_len = max 8 (Cipher.block_len cipher.Cipher.cipher) in
   (* packet_length + padding_length + payload - sequence_length *)
   let buf = Dbuf.reserve Ssh.sizeof_pkt_hdr (Dbuf.create ()) |> Wire.put_message msg in
   let len = Dbuf.used buf in
+  let len = if Cipher.aead cipher.Cipher.cipher then len - 4 else len in
   (* calculate padding *)
   let padlen =
     let x = block_len - (len mod block_len) in
@@ -85,8 +90,8 @@ let encrypt keys msg =
   let pkt = Wire.put_random padlen buf |> Dbuf.to_cstruct in
   Ssh.set_pkt_hdr_pkt_len pkt (Int32.of_int (Cstruct.len pkt - 4));
   Ssh.set_pkt_hdr_pad_len pkt padlen;
-  let digest = hmac mac keys.Kex.seq pkt in
-  let enc, cipher = Cipher.encrypt cipher pkt in
+  let digest = hmac mac seq pkt in
+  let enc, cipher = Cipher.encrypt ~len:false seq cipher pkt in
   let packet = Cstruct.append enc digest in
   let tx_rx = Int64.add keys.Kex.tx_rx
       (Cstruct.len packet |> Int64.of_int)

--- a/test/test.ml
+++ b/test/test.ml
@@ -46,12 +46,15 @@ let cipher_key_of cipher key iv =
   | Plaintext -> { cipher = Plaintext;
                    cipher_key = Plaintext_key }
   | Aes128_ctr | Aes192_ctr | Aes256_ctr ->
-    let iv = Mirage_crypto.Cipher_block.AES.CTR.ctr_of_cstruct iv in
+    let iv = CTR.ctr_of_cstruct iv in
     { cipher;
       cipher_key = Aes_ctr_key ((CTR.of_secret key), iv) }
   | Aes128_cbc | Aes192_cbc | Aes256_cbc ->
     { cipher;
       cipher_key = Aes_cbc_key ((CBC.of_secret key), iv) }
+  | Chacha20_poly1305 ->
+    let key = Mirage_crypto.Chacha20.of_secret key in
+    { cipher; cipher_key = Chacha20_poly1305_key (key, key) }
 
 let hmac_key_of hmac key = Hmac.{ hmac; key }
 


### PR DESCRIPTION
~~this is on top of #13, and requires https://github.com/mirage/mirage-crypto/pull/73 being merged and released.~~

TL;DR: implements https://cvsweb.openbsd.org/src/usr.bin/ssh/PROTOCOL.chacha20poly1305?annotate=HEAD ChaCha20/Poly1305 support for ssh. ssh uses 64 bit nonce (well, the 32 bit sequence number, 0 padded), and 64 bit counter. Two keys are used: one to encrypt the length field, the other to derive a poly1305 secret and encrypt and authenticate the msg. The encrypted length field is part of the data to be authenticated.

When Chacha20/poly1305 is negotiated, there is no hmac in place, since the poly1305 already provides a mac. This makes the Packet.decrypt operation slightly more convoluted (need to take care of mac_len and do some book keeping on it). Also, Cipher.decrypt may now fail (if the sent mac and computed mac are not equal).

Motivation came from #10, cryptographic agility, and recent integration of chacha20/poly1305 into mirage-crypto (still unreleased).