### PR TITLE
new KEX: ECDH_X25519

### DIFF
--- a/awa.opam
+++ b/awa.opam
@@ -32,6 +32,7 @@ depends: [
   "fmt"
   "cmdliner"
   "base64" {>= "3.0.0"}
+  "hacl_x25519"
 ]
 synopsis: "SSH implementation in OCaml"
 description: """The OpenSSH protocol implemented in OCaml."""

--- a/lib/dune
+++ b/lib/dune
@@ -2,4 +2,4 @@
  (name awa)
  (public_name awa)
  (preprocess (pps ppx_cstruct ppx_sexp_conv))
- (libraries cstruct cstruct-sexp mirage-crypto mirage-crypto-rng mirage-crypto-pk zarith x509 mtime sexplib rresult logs base64))
+ (libraries cstruct cstruct-sexp mirage-crypto mirage-crypto-rng mirage-crypto-pk zarith x509 mtime sexplib rresult logs base64 hacl_x25519))

--- a/lib/ssh.ml
+++ b/lib/ssh.ml
@@ -206,6 +206,9 @@ type message =
   | Msg_newkeys
   | Msg_kexdh_reply of Hostkey.pub * mpint * (Hostkey.alg * Cstruct_sexp.t)
   | Msg_kexdh_init of mpint
+  (* from RFC 5656 / 8731 *)
+  | Msg_kexecdh_reply of Hostkey.pub * mpint * (Hostkey.alg * Cstruct_sexp.t)
+  | Msg_kexecdh_init of mpint
   (* from RFC 4419 *)
   (* there's as well a Msg_kexdh_gex_request_old with only a single int32 *)
   | Msg_kexdh_gex_request of int32 * int32 * int32
@@ -249,6 +252,8 @@ let message_to_id = function
   | Msg_newkeys                    -> MSG_NEWKEYS
   | Msg_kexdh_init _               -> MSG_KEX_0
   | Msg_kexdh_reply _              -> MSG_KEX_1
+  | Msg_kexecdh_init _             -> MSG_KEX_0
+  | Msg_kexecdh_reply _            -> MSG_KEX_1
   | Msg_kexdh_gex_request _        -> MSG_KEX_4
   | Msg_kexdh_gex_group _          -> MSG_KEX_1
   | Msg_kexdh_gex_init _           -> MSG_KEX_2


### PR DESCRIPTION
this uses hacl_x25519 to get ECDH_X25519 support for the ssh client.
Since the encoding is slightly different (unsigned mpint instead of mpint),
new messages and code paths are needed (that avoid checks for negative numbers,
potentially adding a leading zero byte). This has been tested against an OpenSSH
server.

Specification in https://tools.ietf.org/html/rfc8731 (should be the same as
https://git.libssh.org/projects/libssh.git/tree/doc/curve25519-sha256@libssh.org.txt),
but I couldn't bother to add support for multiple names for a single kex