### PR TITLE
support for ed25519 keys (hostkey and user authentication)

### DIFF
--- a/awa.opam
+++ b/awa.opam
@@ -32,7 +32,7 @@ depends: [
   "fmt"
   "cmdliner"
   "base64" {>= "3.0.0"}
-  "hacl_x25519"
+  "hacl_x25519" {>= "0.2.0"}
 ]
 synopsis: "SSH implementation in OCaml"
 description: """The OpenSSH protocol implemented in OCaml."""

--- a/lib/hostkey.ml
+++ b/lib/hostkey.ml
@@ -18,39 +18,49 @@ open Mirage_crypto_pk
 
 type priv =
   | Rsa_priv of Rsa.priv
+  | Ed25519_priv of Hacl_ed25519.priv
 
 type pub =
   | Rsa_pub of Rsa.pub
+  | Ed25519_pub of Cstruct.t
 
 let pub_of_priv = function
   | Rsa_priv priv -> Rsa_pub (Rsa.pub_of_priv priv)
+  | Ed25519_priv priv -> Ed25519_pub (Hacl_ed25519.priv_to_public priv)
 
-let sexp_of_pub _ = Sexplib.Sexp.Atom "Hostkey.sexp_of_pub: TODO"
+let sexp_of_pub p =
+  let alg = match p with Rsa_pub _ -> "RSA" | Ed25519_pub _ -> "ED25519" in
+  Sexplib.Sexp.Atom ("Hostkey.sexp_of_pub " ^ alg ^ ": TODO")
 let pub_of_sexp _ = failwith "Hostkey.pub_of_sexp: TODO"
 
 let sshname = function
   | Rsa_pub _ -> "ssh-rsa"
+  | Ed25519_pub _ -> "ssh-ed25519"
 
 type alg =
   | Rsa_sha1
   | Rsa_sha256
   | Rsa_sha512
+  | Ed25519
 
 let hash = function
   | Rsa_sha1 -> `SHA1
   | Rsa_sha256 -> `SHA256
   | Rsa_sha512 -> `SHA512
+  | Ed25519 -> `SHA512
 
 let alg_of_string = function
   | "ssh-rsa" -> Ok Rsa_sha1
   | "rsa-sha2-256" -> Ok Rsa_sha256
   | "rsa-sha2-512" -> Ok Rsa_sha512
+  | "ssh-ed25519" -> Ok Ed25519
   | s -> Error ("Unknown public key algorithm " ^ s)
 
 let alg_to_string = function
   | Rsa_sha1 -> "ssh-rsa"
   | Rsa_sha256 -> "rsa-sha2-256"
   | Rsa_sha512 -> "rsa-sha2-512"
+  | Ed25519 -> "ssh-ed25519"
 
 let alg_of_sexp = function
   | Sexplib.Sexp.Atom s ->
@@ -62,7 +72,7 @@ let alg_of_sexp = function
 
 let sexp_of_alg t = Sexplib.Sexp.Atom (alg_to_string t)
 
-let preferred_algs = [ Rsa_sha256 ; Rsa_sha512 ; Rsa_sha1 ]
+let preferred_algs = [ Ed25519 ; Rsa_sha256 ; Rsa_sha512 ; Rsa_sha1 ]
 
 let signature_equal = Cstruct.equal
 
@@ -71,9 +81,13 @@ let sign alg priv blob =
   | Rsa_priv priv ->
     let hash = hash alg in
     Rsa.PKCS1.sign ~hash ~key:priv (`Message blob)
+  | Ed25519_priv priv ->
+    Hacl_ed25519.sign priv blob
 
 let verify alg pub ~unsigned ~signed =
   match pub with
   | Rsa_pub pub ->
     let hashp h = h = hash alg in
     Rsa.PKCS1.verify ~hashp ~key:pub ~signature:signed (`Message unsigned)
+  | Ed25519_pub pub ->
+    Hacl_ed25519.verify ~pub ~msg:unsigned ~signature:signed

--- a/lib/keys.ml
+++ b/lib/keys.ml
@@ -1,37 +1,39 @@
 
 open Rresult.R.Infix
 
+let src = Logs.Src.create "awa.authenticator" ~doc:"AWA authenticator"
+module Log = (val Logs.src_log src : Logs.LOG)
+
 type authenticator = [
   | `No_authentication
-  | `Key of Mirage_crypto_pk.Rsa.pub
+  | `Key of Hostkey.pub
   | `Fingerprint of string
 ]
 
-let hostkey_matches a = function
-  | Hostkey.Rsa_pub pub ->
-    let hash = Mirage_crypto.Hash.SHA256.digest (Wire.blob_of_pubkey (Hostkey.Rsa_pub pub))  in
-    Logs.app (fun m -> m "authenticating RSA server fingerprint SHA256:%s"
-                 (Base64.encode_string ~pad:false (Cstruct.to_string hash)));
-    match a with
-    | `No_authentication ->
-      Logs.warn (fun m -> m "NO AUTHENTICATOR");
+let hostkey_matches a key =
+  match a with
+  | `No_authentication ->
+    Log.warn (fun m -> m "NO AUTHENTICATOR");
+    true
+  | `Key pub' ->
+    if key = pub' then begin
+      Log.app (fun m -> m "host key verification successful!");
       true
-    | `Key pub' ->
-      if pub = pub' then begin
-        Logs.app (fun m -> m "host RSA key verification successful!");
-        true
-      end else begin
-        Logs.err (fun m -> m "host RSA key verification failed");
-        false
-      end
-    | `Fingerprint s ->
-      if Cstruct.(equal (Cstruct.of_string s) hash) then begin
-        Logs.app (fun m -> m "host fingerprint verification successful!");
-        true
-      end else begin
-        Logs.err (fun m -> m "host fingerprint verification failed");
-        false
-      end
+    end else begin
+      Log.err (fun m -> m "host key verification failed");
+      false
+    end
+  | `Fingerprint s ->
+    let hash = Mirage_crypto.Hash.SHA256.digest (Wire.blob_of_pubkey key) in
+    Log.app (fun m -> m "authenticating server fingerprint SHA256:%s"
+                 (Base64.encode_string ~pad:false (Cstruct.to_string hash)));
+    if Cstruct.(equal (Cstruct.of_string s) hash) then begin
+      Log.app (fun m -> m "host fingerprint verification successful!");
+      true
+    end else begin
+      Log.err (fun m -> m "host fingerprint verification failed");
+      false
+    end
 
 let authenticator_of_string str =
   if str = "" then
@@ -47,19 +49,28 @@ let authenticator_of_string str =
     | _ ->
       match Base64.decode ~pad:false str with
       | Ok k ->
-        (Wire.pubkey_of_blob (Cstruct.of_string k) >>= function
-          | Hostkey.Rsa_pub key -> Ok (`Key key))
+        (Wire.pubkey_of_blob (Cstruct.of_string k) >>| fun key ->
+         `Key key)
       | Error (`Msg msg) ->
         Error (str ^ " is invalid or unsupported authenticator, b64 failed: " ^ msg)
 
-let of_seed seed =
+let of_seed ?(typ = `RSA) seed =
   let g =
     let seed = Cstruct.of_string seed in
     Mirage_crypto_rng.(create ~seed (module Fortuna))
   in
-  let key = Mirage_crypto_pk.Rsa.generate ~g ~bits:2048 () in
-  let public = Mirage_crypto_pk.Rsa.pub_of_priv key in
-  let pubkey = Wire.blob_of_pubkey (Hostkey.Rsa_pub public) in
-  Logs.info (fun m -> m "using ssh-rsa %s"
-               (Cstruct.to_string pubkey |> Base64.encode_string));
-  Hostkey.Rsa_priv key
+  match typ with
+  | `RSA ->
+    let key = Mirage_crypto_pk.Rsa.generate ~g ~bits:2048 () in
+    let public = Mirage_crypto_pk.Rsa.pub_of_priv key in
+    let pubkey = Wire.blob_of_pubkey (Hostkey.Rsa_pub public) in
+    Log.info (fun m -> m "using ssh-rsa %s"
+                 (Cstruct.to_string pubkey |> Base64.encode_string));
+    Hostkey.Rsa_priv key
+  | `Ed25519 ->
+    let key = Hacl_ed25519.priv (Mirage_crypto_rng.generate ~g 32) in
+    let public = Hacl_ed25519.priv_to_public key in
+    let pubkey = Wire.blob_of_pubkey (Hostkey.Ed25519_pub public) in
+    Log.info (fun m -> m "using ssh-ed25519 %s"
+                 (Cstruct.to_string pubkey |> Base64.encode_string));
+    Hostkey.Ed25519_priv key

--- a/lib/wire.ml
+++ b/lib/wire.ml
@@ -184,6 +184,62 @@ let privkey_of_pem buf =
   X509.Private_key.decode_pem buf >>| fun (`RSA key) ->
   Hostkey.Rsa_priv key
 
+let privkey_of_openssh buf =
+  (* as defined in https://cvsweb.openbsd.org/cgi-bin/cvsweb/~checkout~/src/usr.bin/ssh/PROTOCOL.key?rev=1.1&content-type=text/plain *)
+  let id s =
+    let dash = "-----" in
+    dash ^ (if s then "BEGIN" else "END") ^ " OPENSSH PRIVATE KEY" ^ dash
+  in
+  let data = Cstruct.to_string buf in
+  (match String.split_on_char '\n' data with
+   | hd :: data ->
+     begin match List.rev data with
+       | "" :: last :: data' | last :: data' ->
+         let data = String.concat "" (List.rev data') in
+         if String.equal hd (id true) && String.equal last (id false) then
+           Rresult.R.reword_error (function `Msg m -> m ) (Base64.decode data)
+         else
+           Error "not an OpenSSH private key"
+       | [] -> Error "not a valid OpenSSH private key"
+     end
+   | [] -> Error "invalid OpenSSH private key") >>= fun data ->
+  let cs = Cstruct.of_string data in
+  let auth_magic = Cstruct.of_string "openssh-key-v1\000" in
+  let pre, cs = Cstruct.split cs (Cstruct.len auth_magic) in
+  guard (Cstruct.equal pre auth_magic) "bad auth magic" >>= fun () ->
+  get_string cs >>= fun (cipher, cs) ->
+  guard (String.equal cipher "none") "only unencrypted private keys supported" >>= fun () ->
+  get_string cs >>= fun (kdf, cs) ->
+  guard (String.equal kdf "none") "only unencrypted private keys supported" >>= fun () ->
+  get_string cs >>= fun (kdfopts, cs) ->
+  guard (String.equal kdfopts "") "only no kdfoptions supported" >>= fun () ->
+  get_uint32 cs >>= fun (keys, cs) ->
+  guard (keys = 1l) "only one key supported" >>= fun () ->
+  get_uint32 cs >>= fun (pklen, cs) ->
+  get_uint32 (Cstruct.shift cs (Int32.to_int pklen)) >>= fun (_plen, priv) ->
+  (* 64 bit checkint - useful when crypted *)
+  get_string (Cstruct.shift priv 8) >>= fun (keytype, cs) ->
+  match keytype with
+  | "ssh-ed25519" ->
+    get_cstring cs >>= fun (_pub, cs) ->
+    get_cstring cs >>= fun (priv, cs) ->
+    get_string cs >>= fun (comment, _padding) ->
+    let priv = Cstruct.sub priv 0 32 in
+    Ok (Hostkey.Ed25519_priv (Hacl_ed25519.priv priv), comment)
+  | "ssh-rsa" ->
+    get_mpint cs >>= fun (n, cs) ->
+    get_mpint cs >>= fun (e, cs) ->
+    get_mpint cs >>= fun (d, cs) ->
+    get_mpint cs >>= fun (q', cs) ->
+    get_mpint cs >>= fun (p, cs) ->
+    get_mpint cs >>= fun (q, cs) ->
+    get_string cs >>= fun (comment, _padding) ->
+    let dp = Z.(d mod (pred p)) and dq = Z.(d mod (pred q)) in
+    Rresult.R.reword_error (function `Msg m -> m)
+      (Mirage_crypto_pk.Rsa.priv ~e ~d ~n ~p ~q ~dp ~dq ~q') >>= fun p ->
+    Ok (Hostkey.Rsa_priv p, comment)
+  | x -> Error ("unsupported key type " ^ x)
+
 let put_kexinit kex t =
   let open Ssh in
   let nll = [ kex.kex_algs;

--- a/test/awa_gen_key.ml
+++ b/test/awa_gen_key.ml
@@ -1,5 +1,5 @@
 
-let gen_key seed =
+let gen_key seed typ =
   Mirage_crypto_rng_unix.initialize ();
   let b64s x = Cstruct.to_string x |> Base64.encode_string in
   let seed = match seed with
@@ -7,10 +7,10 @@ let gen_key seed =
     | Some x -> x
   in
   Printf.printf "seed is %s\n" seed;
-  let hostkey = Awa.Keys.of_seed seed in
+  let hostkey = Awa.Keys.of_seed ~typ seed in
   let pub = Awa.Hostkey.pub_of_priv hostkey in
   let public = Awa.Wire.blob_of_pubkey pub in
-  Printf.printf "ssh-rsa %s awa@awa.local\n" (b64s public);
+  Printf.printf "%s %s awa@awa.local\n" (Awa.Hostkey.sshname pub) (b64s public);
   Ok ()
 
 open Cmdliner
@@ -19,8 +19,12 @@ let seed =
   let doc = "Seed for private key." in
   Arg.(value & opt (some string) None & info [ "seed" ] ~doc)
 
+let keytype =
+  let doc = "private key type" in
+  Arg.(value & opt (enum [ ("rsa", `RSA) ; ("ed25519", `Ed25519) ]) `RSA & info [ "keytype" ] ~doc)
+
 let cmd =
-  Term.(term_result (const gen_key $ seed)),
+  Term.(term_result (const gen_key $ seed $ keytype)),
   Term.info "albatross_stat_client" ~version:"%%VERSION_NUM%%"
 
 let () = match Term.eval cmd with `Ok () -> exit 0 | _ -> exit 1


### PR DESCRIPTION
as specified in https://tools.ietf.org/html/rfc8709

~~this requires hacl on master (or a fresh release thereof) for ed25519 support. there's no support (yet) for decoding and encoding private keys in OpenSSH format (BEGIN OPENSSH PRIVATE KEY), needs investigation what is actually stored in there (I suspect the Wire.privkey_of_pem -- which use X509.Private_key.decode_pem -- is the way to look at, but my local ed25519 key is not a valid PEM).~~