### PR TITLE
include a key type in the Fingerprint authenticator.

### DIFF
--- a/lib/client.ml
+++ b/lib/client.ml
@@ -106,7 +106,13 @@ let output_msgs t msgs =
 
 let make ?(authenticator = `No_authentication) ~user key =
   let open Ssh in
-  let client_kexinit = Kex.make_kexinit Kex.client_supported () in
+  let hostkey_algs = match authenticator with
+    | `No_authentication -> Hostkey.preferred_algs
+    | `Key Hostkey.Rsa_pub _ -> Hostkey.algs_of_typ `Rsa
+    | `Key Hostkey.Ed25519_pub _ -> Hostkey.algs_of_typ `Ed25519
+    | `Fingerprint (typ, _) -> Hostkey.algs_of_typ typ
+  in
+  let client_kexinit = Kex.make_kexinit hostkey_algs Kex.client_supported () in
   let banner_msg = Ssh.Msg_version version_banner in
   let kex_msg = Ssh.Msg_kexinit client_kexinit in
   let t = { state = Init (version_banner, client_kexinit);

--- a/lib/hostkey.ml
+++ b/lib/hostkey.ml
@@ -74,6 +74,10 @@ let sexp_of_alg t = Sexplib.Sexp.Atom (alg_to_string t)
 
 let preferred_algs = [ Ed25519 ; Rsa_sha256 ; Rsa_sha512 ; Rsa_sha1 ]
 
+let algs_of_typ = function
+  | `Ed25519 -> [ Ed25519 ]
+  | `Rsa -> [ Rsa_sha256 ; Rsa_sha512 ; Rsa_sha1 ]
+
 let signature_equal = Cstruct.equal
 
 let sign alg priv blob =

--- a/lib/kex.ml
+++ b/lib/kex.ml
@@ -95,11 +95,11 @@ let server_supported =
   [ Diffie_hellman_group14_sha256 ; Diffie_hellman_group14_sha1 ;
     Diffie_hellman_group1_sha1 ]
 
-let make_kexinit algs () =
+let make_kexinit host_key_algs algs () =
   let k =
     { cookie = Mirage_crypto_rng.generate 16;
       kex_algs = List.map alg_to_string algs;
-      server_host_key_algs = List.map Hostkey.alg_to_string Hostkey.preferred_algs;
+      server_host_key_algs = List.map Hostkey.alg_to_string host_key_algs;
       encryption_algs_ctos = List.map Cipher.to_string Cipher.preferred;
       encryption_algs_stoc = List.map Cipher.to_string Cipher.preferred;
       mac_algs_ctos = List.map Hmac.to_string Hmac.preferred;

--- a/lib/keys.ml
+++ b/lib/keys.ml
@@ -71,7 +71,7 @@ let authenticator_of_string str =
       | Error (`Msg msg) ->
         Error (str ^ " is invalid or unsupported authenticator, b64 failed: " ^ msg)
 
-let of_seed ?(typ = `Rsa) seed =
+let of_seed typ seed =
   let g =
     let seed = Cstruct.of_string seed in
     Mirage_crypto_rng.(create ~seed (module Fortuna))

--- a/lib/keys.ml
+++ b/lib/keys.ml
@@ -4,10 +4,18 @@ open Rresult.R.Infix
 let src = Logs.Src.create "awa.authenticator" ~doc:"AWA authenticator"
 module Log = (val Logs.src_log src : Logs.LOG)
 
+type typ = [ `Rsa | `Ed25519 ]
+
+let typ_of_string s =
+  match String.lowercase_ascii s with
+  | "rsa" -> Ok `Rsa
+  | "ed25519" -> Ok `Ed25519
+  | _ -> Error ("unknown key type " ^ s)
+
 type authenticator = [
   | `No_authentication
   | `Key of Hostkey.pub
-  | `Fingerprint of string
+  | `Fingerprint of typ * string
 ]
 
 let hostkey_matches a key =
@@ -23,11 +31,17 @@ let hostkey_matches a key =
       Log.err (fun m -> m "host key verification failed");
       false
     end
-  | `Fingerprint s ->
+  | `Fingerprint (typ, s) ->
     let hash = Mirage_crypto.Hash.SHA256.digest (Wire.blob_of_pubkey key) in
     Log.app (fun m -> m "authenticating server fingerprint SHA256:%s"
-                 (Base64.encode_string ~pad:false (Cstruct.to_string hash)));
-    if Cstruct.(equal (Cstruct.of_string s) hash) then begin
+                (Base64.encode_string ~pad:false (Cstruct.to_string hash)));
+    let typ_matches = match typ, key with
+      | `Ed25519, Hostkey.Ed25519_pub _ -> true
+      | `Rsa, Hostkey.Rsa_pub _ -> true
+      | _ -> false
+    and fp_matches = Cstruct.(equal (of_string s) hash)
+    in
+    if typ_matches && fp_matches then begin
       Log.app (fun m -> m "host fingerprint verification successful!");
       true
     end else begin
@@ -40,11 +54,14 @@ let authenticator_of_string str =
     Ok `No_authentication
   else
     match Astring.String.cut ~sep:":" str with
-    | Some ("SHA256", fp) ->
+    | Some (y, fp) ->
+      (match y with
+       | "SHA256" -> Ok `Rsa
+       | y -> typ_of_string y) >>= fun t ->
       begin match Base64.decode ~pad:false fp with
         | Error (`Msg m) ->
           Error ("invalid authenticator (bad b64 in fingerprint): " ^ m)
-        | Ok fp -> Ok (`Fingerprint fp)
+        | Ok fp -> Ok (`Fingerprint (t, fp))
       end
     | _ ->
       match Base64.decode ~pad:false str with
@@ -54,13 +71,13 @@ let authenticator_of_string str =
       | Error (`Msg msg) ->
         Error (str ^ " is invalid or unsupported authenticator, b64 failed: " ^ msg)
 
-let of_seed ?(typ = `RSA) seed =
+let of_seed ?(typ = `Rsa) seed =
   let g =
     let seed = Cstruct.of_string seed in
     Mirage_crypto_rng.(create ~seed (module Fortuna))
   in
   match typ with
-  | `RSA ->
+  | `Rsa ->
     let key = Mirage_crypto_pk.Rsa.generate ~g ~bits:2048 () in
     let public = Mirage_crypto_pk.Rsa.pub_of_priv key in
     let pubkey = Wire.blob_of_pubkey (Hostkey.Rsa_pub public) in

--- a/lib/server.ml
+++ b/lib/server.ml
@@ -57,7 +57,9 @@ let guard_msg t msg =
 
 let make host_key user_db =
   let open Ssh in
-  let server_kexinit = Kex.make_kexinit Kex.server_supported () in
+  let server_kexinit =
+    Kex.make_kexinit Hostkey.preferred_algs Kex.server_supported ()
+  in
   let banner_msg = Ssh.Msg_version version_banner in
   let kex_msg = Ssh.Msg_kexinit server_kexinit in
   { client_version = None;
@@ -99,7 +101,9 @@ let of_new_keys_stoc t =
 let rekey t =
   match t.keying, (Kex.is_keyed t.keys_stoc) with
   | false, true ->              (* can't be keying and must be keyed *)
-    let server_kexinit = Kex.make_kexinit Kex.server_supported () in
+    let server_kexinit =
+      Kex.make_kexinit Hostkey.preferred_algs Kex.server_supported ()
+    in
     let t = { t with server_kexinit; keying = true } in
     Some (t, Ssh.Msg_kexinit server_kexinit)
   | _ -> None

--- a/test/awa_gen_key.ml
+++ b/test/awa_gen_key.ml
@@ -7,7 +7,7 @@ let gen_key seed typ =
     | Some x -> x
   in
   Printf.printf "seed is %s\n" seed;
-  let hostkey = Awa.Keys.of_seed ~typ seed in
+  let hostkey = Awa.Keys.of_seed typ seed in
   let pub = Awa.Hostkey.pub_of_priv hostkey in
   let public = Awa.Wire.blob_of_pubkey pub in
   Printf.printf "%s %s awa@awa.local\n" (Awa.Hostkey.sshname pub) (b64s public);

--- a/test/awa_gen_key.ml
+++ b/test/awa_gen_key.ml
@@ -21,7 +21,7 @@ let seed =
 
 let keytype =
   let doc = "private key type" in
-  Arg.(value & opt (enum [ ("rsa", `RSA) ; ("ed25519", `Ed25519) ]) `RSA & info [ "keytype" ] ~doc)
+  Arg.(value & opt (enum [ ("rsa", `Rsa) ; ("ed25519", `Ed25519) ]) `Rsa & info [ "keytype" ] ~doc)
 
 let cmd =
   Term.(term_result (const gen_key $ seed $ keytype)),

--- a/test/awa_test_client.ml
+++ b/test/awa_test_client.ml
@@ -34,7 +34,7 @@ let jump _ user seed typ authenticator host port =
   Unix.(connect fd (ADDR_INET (inet_addr_of_string host, port)));
   match
     Keys.authenticator_of_string authenticator >>= fun authenticator ->
-    let t, out = Client.make ~authenticator ~user (Keys.of_seed ~typ seed) in
+    let t, out = Client.make ~authenticator ~user (Keys.of_seed typ seed) in
     List.iter (write_cstruct fd) out;
     let rec read_react t =
       let data = read_cstruct fd in

--- a/test/awa_test_client.ml
+++ b/test/awa_test_client.ml
@@ -81,7 +81,7 @@ let seed =
 
 let keytype =
   let doc = "private key type" in
-  Arg.(value & opt (enum [ ("rsa", `RSA) ; ("ed25519", `Ed25519) ]) `RSA & info [ "keytype" ] ~doc)
+  Arg.(value & opt (enum [ ("rsa", `Rsa) ; ("ed25519", `Ed25519) ]) `Rsa & info [ "keytype" ] ~doc)
 
 let authenticator =
   let doc = "authenticator" in

--- a/test/test.ml
+++ b/test/test.ml
@@ -416,7 +416,7 @@ let t_ignore_next_packet () =
   let t = Server.{ t with client_version = Some "SSH-2.0-client";
                           expect = Some(Ssh.MSG_KEXINIT) }
   in
-  let kexinit = Ssh.{ (Kex.make_kexinit Kex.client_supported ()) with
+  let kexinit = Ssh.{ (Kex.make_kexinit Hostkey.preferred_algs Kex.client_supported ()) with
                       encryption_algs_ctos = ["aes256-cbc"];
                       first_kex_packet_follows = true }
   in


### PR DESCRIPTION
also use this information for "host key algorithms"

the authenticator_of_string now supports:
SHA256:<b64-encoded-sha256-fingerprint-of-RSA-public-key>
rsa:<b64-encoded-sha256-fingerprint-of-RSA-public-key>
ed25519:<b64-encoded-sha256-fingerprint-of-RSA-public-key>
<raw public key (already including ssh-rsa/ssh-ed25519>
"" none

fixes #18