### PR TITLE
client: only attempt algorithms that match the private key type

### DIFF
--- a/awa-lwt.opam
+++ b/awa-lwt.opam
@@ -17,9 +17,11 @@ depends: [
   "ocaml" {>= "4.04.2"}
   "dune" {build & >= "1.0"}
   "awa" {= version}
-  "cstruct"       {>= "1.9.0"}
+  "cstruct"       {>= "3.2.0"}
   "mtime"
   "lwt"
+  "cstruct-unix"
+  "mirage-crypto-rng"
 ]
 synopsis: "SSH implementation in OCaml"
 description: """The OpenSSH protocol implemented in OCaml."""

--- a/awa.opam
+++ b/awa.opam
@@ -22,7 +22,7 @@ depends: [
   "mirage-crypto-rng"
   "mirage-crypto-pk"
   "x509" {>= "0.10.0"}
-  "cstruct" {>= "1.9.0"}
+  "cstruct" {>= "3.2.0"}
   "cstruct-unix"
   "cstruct-sexp"
   "sexplib"
@@ -33,6 +33,7 @@ depends: [
   "cmdliner"
   "base64" {>= "3.0.0"}
   "hacl_x25519" {>= "0.2.0"}
+  "zarith"
 ]
 synopsis: "SSH implementation in OCaml"
 description: """The OpenSSH protocol implemented in OCaml."""

--- a/lib/client.ml
+++ b/lib/client.ml
@@ -156,7 +156,8 @@ let handle_kexinit t c_v ckex s_v skex =
           match Hostkey.alg_of_string a with Ok a -> a :: acc | Error _ -> acc)
         [] skex.server_host_key_algs
     in
-    List.filter (fun a -> List.mem a s) Hostkey.preferred_algs
+    let s = List.filter (fun a -> List.mem a s) Hostkey.preferred_algs in
+    List.filter Hostkey.(alg_matches (priv_to_typ t.key)) s
   in
   ok ({ t with state ; sig_algs }, [ msg ], [])
 

--- a/lib/hostkey.ml
+++ b/lib/hostkey.ml
@@ -78,6 +78,12 @@ let algs_of_typ = function
   | `Ed25519 -> [ Ed25519 ]
   | `Rsa -> [ Rsa_sha256 ; Rsa_sha512 ; Rsa_sha1 ]
 
+let priv_to_typ = function
+  | Rsa_priv _ -> `Rsa
+  | Ed25519_priv _ -> `Ed25519
+
+let alg_matches typ alg = List.mem alg (algs_of_typ typ)
+
 let signature_equal = Cstruct.equal
 
 let sign alg priv blob =

--- a/lwt/awa_lwt.ml
+++ b/lwt/awa_lwt.ml
@@ -52,16 +52,12 @@ let wrapr = function
   | Ok x -> Lwt.return x
   | Error e -> Lwt.fail_invalid_arg e
 
-(* XXX REMOVE ME ONCE WE DONT CONFLICT WITH NEW CSTRUCT *)
-let cs_to_bytes buf =
-  Cstruct.to_string buf |> Bytes.of_string
-
 let send_msg fd server msg =
   wrapr (Awa.Server.output_msg server msg)
   >>= fun (server, msg_buf) ->
   Lwt_io.printf ">>> %s\n%!" (Awa.Ssh.message_to_string msg)
   >>= fun () ->
-  Lwt_unix.write fd (cs_to_bytes msg_buf) 0 (Cstruct.len msg_buf)
+  Lwt_unix.write fd (Cstruct.to_bytes msg_buf) 0 (Cstruct.len msg_buf)
   >>= fun n ->
   assert (n = Cstruct.len msg_buf);
   Lwt.return server

--- a/test/test.ml
+++ b/test/test.ml
@@ -602,7 +602,8 @@ let all_tests = [
   (t_ignore_next_packet, "ignore next packet");
   (t_channel_input, "channel data input");
   (t_channel_output, "channel data output");
-  (t_openssh_client, "OpenSSH@awa_ssh echo server");
+  (* disabled: requires network connectivity
+     (t_openssh_client, "OpenSSH@awa_ssh echo server"); *)
 ]
 
 let _ =


### PR DESCRIPTION
this avoids `Jan  7 10:58:07 <auth.err> sshd[87597]: error: userauth_pubkey: type mismatch for decoded key (received 0, expected 3) [preauth]` messages when awa attempted to use ed25519 signature with an rsa key
