### PR TITLE
add ssh subsytem option

### DIFF
--- a/awa-mirage.opam
+++ b/awa-mirage.opam
@@ -21,6 +21,7 @@ depends: [
   "mtime"
   "lwt"
   "mirage-time"
+  "duration" {>= "0.2.0"}
   "mirage-flow" {>= "2.0.0"}
   "mirage-clock" {>= "3.0.0"}
   "logs"

--- a/awa-mirage.opam
+++ b/awa-mirage.opam
@@ -20,6 +20,7 @@ depends: [
   "cstruct" {>= "6.0.0"}
   "mtime"
   "lwt"
+  "mirage-time"
   "mirage-flow" {>= "2.0.0"}
   "mirage-clock" {>= "3.0.0"}
   "logs"

--- a/lib/server.ml
+++ b/lib/server.ml
@@ -18,6 +18,7 @@ open Util
 
 type event =
   | Channel_exec of (int32 * string)
+  | Channel_subsystem of (int32 * string)
   | Channel_data of (int32 * Cstruct.t)
   | Channel_eof of int32
   | Disconnected of string
@@ -270,7 +271,7 @@ let input_channel_request t recp_channel want_reply data =
     | Env (_key, _value) -> success t  (* TODO implement me *)
     | Shell -> fail t
     | Exec cmd -> event t (Channel_exec (c, cmd))
-    | Subsystem _ -> fail t
+    | Subsystem cmd -> event t (Channel_subsystem (c, cmd))
     | Window_change _ -> fail t
     | Xon_xoff _ -> fail t
     | Signal _ -> fail t

--- a/lwt/awa_lwt.ml
+++ b/lwt/awa_lwt.ml
@@ -144,6 +144,7 @@ let rec nexus t fd server input_buffer =
        | None -> Lwt.return_unit)
       >>= fun () ->
       nexus t fd server input_buffer
+    | Some Awa.Server.Channel_subsystem (id, cmd) (* same as exec *)
     | Some Awa.Server.Channel_exec (id, cmd) ->
       (* Create an input box *)
       let sshin_mbox = Lwt_mvar.create_empty () in

--- a/mirage/awa_mirage.ml
+++ b/mirage/awa_mirage.ml
@@ -1,4 +1,3 @@
-open Lwt
 open Lwt.Infix
 
 module Make (F : Mirage_flow.S) (M : Mirage_clock.MCLOCK) = struct
@@ -249,7 +248,7 @@ module Make (F : Mirage_flow.S) (M : Mirage_clock.MCLOCK) = struct
       >>= fun server ->
       match event with
       | None -> nexus t fd server input_buffer
-      | Some Awa.Server.Disconnected s ->
+      | Some Awa.Server.Disconnected _ ->
         Lwt_list.iter_p sshin_eof t.channels
         >>= fun () ->
         Lwt.return t

--- a/mirage/awa_mirage.ml
+++ b/mirage/awa_mirage.ml
@@ -221,10 +221,10 @@ module Make (F : Mirage_flow.S) (T : Mirage_time.S) (M : Mirage_clock.MCLOCK) = 
     | None -> (* No SSH msg *)
       Lwt.catch
         (fun () ->
-          let timeout = T.sleep_ns 2000000L >>= fun () -> Lwt.return Rekey in
-          Lwt.pick [ Lwt_mvar.take t.nexus_mbox;
+          let timeout = T.sleep_ns 2000000000L >>= fun () -> Lwt.return Rekey in
+          Lwt.pick [ Lwt_mvar.take t.nexus_mbox ;
                       net_read fd ;
-                      timeout])
+                      timeout ])
       (function exn -> Lwt.fail exn)
       >>= fun nexus_msg ->
       (match nexus_msg with

--- a/mirage/awa_mirage.ml
+++ b/mirage/awa_mirage.ml
@@ -141,7 +141,7 @@ module Make (F : Mirage_flow.S) (M : Mirage_clock.MCLOCK) = struct
 
 (* copy from awa_lwt.ml and unix references removed in favor to FLOW *)
   type nexus_msg =
-    | Rekey
+    (*| Rekey*)
     | Net_eof
     | Net_io of Cstruct.t
     | Sshout of (int32 * Cstruct.t)
@@ -221,20 +221,19 @@ module Make (F : Mirage_flow.S) (M : Mirage_clock.MCLOCK) = struct
     | None -> (* No SSH msg *)
       Lwt.catch
         (fun () ->
-          let timeout = Mtime.timeout 2_000_000_000L >>= fun () -> Error (`Msg "DNS request timeout") in
            Lwt.pick [ Lwt_mvar.take t.nexus_mbox;
-                      net_read fd;
-                      timeout ])
-      (function `Error -> Lwt.return Rekey | exn -> Lwt.fail exn)
+                      net_read fd (* ;
+                      some_way_to_timeout 2_sec *) ])
+      (function (*`Error -> Lwt.return Rekey | *)exn -> Lwt.fail exn)
       >>= fun nexus_msg ->
       (match nexus_msg with
-       | Rekey ->
+        (*| Rekey ->
           (match Awa.Server.maybe_rekey server (now ()) with
           | None -> nexus t fd server input_buffer
           | Some (server, kexinit) ->
             send_msg fd server kexinit
             >>= fun server ->
-            nexus t fd server input_buffer)
+            nexus t fd server input_buffer)*)
        | Net_eof ->
          Lwt.return t
        | Net_io buf -> nexus t fd server (Awa.Util.cs_join input_buffer buf)

--- a/mirage/awa_mirage.mli
+++ b/mirage/awa_mirage.mli
@@ -1,7 +1,7 @@
 (** Effectful operations using Mirage for pure SSH. *)
 
 (** SSH module given a flow *)
-module Make (F : Mirage_flow.S) (M : Mirage_clock.MCLOCK) : sig
+module Make (F : Mirage_flow.S) (T : Mirage_time.S) (M : Mirage_clock.MCLOCK) : sig
 
   module FLOW : Mirage_flow.S
 

--- a/mirage/awa_mirage.mli
+++ b/mirage/awa_mirage.mli
@@ -26,5 +26,22 @@ module Make (F : Mirage_flow.S) (M : Mirage_clock.MCLOCK) : sig
     Awa.Hostkey.priv -> Awa.Ssh.channel_request -> FLOW.flow ->
     (flow, error) result Lwt.t
 
+ type t
+
+  type sshin_msg = [
+    | `Data of Cstruct.t
+    | `Eof
+  ]
+
+  type exec_callback =
+    string ->                     (* cmd *)
+    (unit -> sshin_msg Lwt.t) ->  (* sshin *)
+    (Cstruct.t -> unit Lwt.t) ->  (* sshout *)
+    (Cstruct.t -> unit Lwt.t) ->  (* ssherr *)
+    unit Lwt.t
+
+  val spawn_server : Awa.Server.t -> Awa.Ssh.message list -> F.flow ->
+    exec_callback -> t Lwt.t
+
 end
   with module FLOW = F

--- a/mirage/dune
+++ b/mirage/dune
@@ -2,4 +2,4 @@
  (name awa_mirage)
  (public_name awa-mirage)
  (wrapped false)
- (libraries awa mirage-flow mirage-clock mirage-time lwt mtime logs))
+ (libraries awa mirage-flow mirage-clock mirage-time duration lwt mtime logs))

--- a/mirage/dune
+++ b/mirage/dune
@@ -2,4 +2,4 @@
  (name awa_mirage)
  (public_name awa-mirage)
  (wrapped false)
- (libraries awa mirage-flow mirage-clock lwt mtime logs))
+ (libraries awa mirage-flow mirage-clock mirage-time lwt mtime logs))

--- a/test/awa_test_server.ml
+++ b/test/awa_test_server.ml
@@ -87,6 +87,7 @@ let rec serve t cmd =
        let* t = bc t id data in
        serve t cmd
      | _ -> Error "Unexpected cmd")
+  | Channel_subsystem (id, exec) (* same as exec *)
   | Channel_exec (id, exec) ->
     printf "channel exec %s\n%!" exec;
     match exec with


### PR DESCRIPTION
This PR adds the `subsystem` option to the ssh protocol, this will allow to reply to sshfs mount requests and share files with mirage :)

`mirage/awa_mirage.ml` has stolen a lot from `lwt/awa_lwt.ml` and I'm not sure that the `| Some Awa.Server.Channel_subsystem (id, cmd)` is still needed in `lwt/awa_lwt` as I now solely use the `mirage/awa_mirage`.

I'm currently not aware of any other uses of the subsystem option, this is why I did not restrict it to sftp.

Many thanks to @hannesm for his precious help in this work !