### PR TITLE
Fix isomorphism between of_seed/of_string and awa_gen_key

### DIFF
--- a/lib/keys.ml
+++ b/lib/keys.ml
@@ -96,7 +96,7 @@ let of_string str =
   match String.split_on_char ':' str with
   | [ typ; data; ] ->
     ( match typ_of_string typ, Base64.decode data with
-    | Ok `Rsa, Ok seed -> Ok (of_seed `Rsa seed)
+    | Ok `Rsa, Ok _seed -> Ok (of_seed `Rsa data)
     | Ok `Ed25519, Ok key ->
       ( match Mirage_crypto_ec.Ed25519.priv_of_cstruct (Cstruct.of_string key) with
       | Ok key -> Ok (Hostkey.Ed25519_priv key)


### PR DESCRIPTION
During my test, I saw that the seed generated  by `awa_gen_key` does not produce the same private key then _via_ `Keys.of_string` function. It's mostly because the seed given to `Awa.Keys.of_seed` was previously this patch the base64 value (instead of the raw value). So, when `of_string` tries to decode the `seed` _via_ `Base64.decode` and pass it to `of_seed`, the generated key is not the same that the one generated _via_ `awa_gen_key`.

This patch ensure that:
- `awa_gen_key` generates a key from seed and show the Base64 encoded seed to the terminal
- `of_string` still continue to take the Base64 encoded seed and decode it to pass then the raw value to `of_seed`