### PR TITLE
Use Eqaf and hash to test the password

### DIFF
--- a/awa.opam
+++ b/awa.opam
@@ -33,6 +33,7 @@ depends: [
   "cmdliner"
   "base64" {>= "3.0.0"}
   "zarith"
+  "eqaf" {>= "0.8"}
 ]
 conflicts: [ "result" {< "1.5"} ]
 synopsis: "SSH implementation in OCaml"

--- a/lib/auth.ml
+++ b/lib/auth.ml
@@ -46,7 +46,12 @@ let lookup_user_key user key db =
 let by_password name password db =
   match lookup_user name db with
   | None -> false
-  | Some user -> user.password = Some password
+  | Some user -> match user.password with
+    | Some password' ->
+      let a = Mirage_crypto.Hash.digest `SHA256 (Cstruct.of_string password')
+      and b = Mirage_crypto.Hash.digest `SHA256 (Cstruct.of_string password) in
+      Eqaf_cstruct.equal a b
+    | None -> false
 
 let to_hash name alg pubkey session_id service =
   let open Wire in

--- a/lib/dune
+++ b/lib/dune
@@ -2,4 +2,4 @@
  (name awa)
  (public_name awa)
  (preprocess (pps ppx_cstruct ppx_sexp_conv))
- (libraries cstruct cstruct-sexp mirage-crypto mirage-crypto-rng mirage-crypto-pk zarith x509 mtime sexplib logs base64 mirage-crypto-ec))
+ (libraries eqaf.cstruct cstruct cstruct-sexp mirage-crypto mirage-crypto-rng mirage-crypto-pk zarith x509 mtime sexplib logs base64 mirage-crypto-ec))


### PR DESCRIPTION
A simple patch to use `eqaf` when we want to check the password - `eqaf` is already into the dependency graph.