### PR TITLE
Client, accept stderr passed via channel extended data

### DIFF
--- a/lib/client.mli
+++ b/lib/client.mli
@@ -22,6 +22,7 @@ val make : ?authenticator:Keys.authenticator -> user:string -> Hostkey.priv ->
 type event = [
   | `Established of int32
   | `Channel_data of int32 * Cstruct.t
+  | `Channel_stderr of int32 * Cstruct.t
   | `Channel_eof of int32
   | `Channel_exit_status of int32 * int32
   | `Disconnected


### PR DESCRIPTION
When executing shell commands, the ssh server can send stderr via the extended data channel:

https://github.com/mirage/awa-ssh/blob/d85a95c90a6ef7816c8bc093742fb841ea176680/docs/rfc4254.txt#L412-L432

But currently, the awa client fails with an `"unexpected state and message"` since it doesn't expect any `Msg_channel_extended_data`. Note that this PR only handles the `SSH_EXTENDED_DATA_STDERR=1` case as I'm not aware of other extensions, but perhaps it should return a generic `` `Channel_extended_data (id, data_type_code, data)`` and leave the user to interpret the meaning of `data_type_code`?