### PR TITLE
Disable code formatting in dune-project.

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -1,3 +1,4 @@
 (lang dune 2.7)
 (name awa)
 (cram enable)
+(formatting disabled)


### PR DESCRIPTION
There is no configuration for ocamlformat.