### PR TITLE
Output keys (key seeds) as of_string expects

### DIFF
--- a/lib/keys.ml
+++ b/lib/keys.ml
@@ -11,6 +11,10 @@ let typ_of_string s =
   | "ed25519" -> Ok `Ed25519
   | _ -> Error ("unknown key type " ^ s)
 
+let string_of_typ = function
+  | `Rsa -> "rsa"
+  | `Ed25519 -> "ed25519"
+
 type authenticator = [
   | `No_authentication
   | `Key of Hostkey.pub

--- a/test/awa_gen_key.ml
+++ b/test/awa_gen_key.ml
@@ -10,9 +10,12 @@ let gen_key seed typ =
   (match hostkey with
    | Awa.Hostkey.Ed25519_priv k ->
      let p = Mirage_crypto_ec.Ed25519.priv_to_cstruct k in
-     Printf.printf "ED25519 private key %s\n" (b64s p)
+     Printf.printf "private key: %s:%s\n"
+       Awa.Keys.(string_of_typ `Ed25519)
+       (b64s p)
    | Rsa_priv _ ->
-     Printf.printf "seed is %s\n" seed);
+     Printf.printf "private key seed: %s:%s\n"
+       Awa.Keys.(string_of_typ `Rsa) seed);
   let pub = Awa.Hostkey.pub_of_priv hostkey in
   let public = Awa.Wire.blob_of_pubkey pub in
   Printf.printf "%s %s awa@awa.local\n" (Awa.Hostkey.sshname pub) (b64s public);

--- a/test/iso-ed25519.t
+++ b/test/iso-ed25519.t
@@ -1,0 +1,5 @@
+  $ awa_gen_key --keytype ed25519 > a.key
+  $ cat a.key | tail -n1 > a.public_key
+  $ cat a.key | head -n1 | cut -d' ' -f3 > a.seed
+  $ ./public_key_of_seed.exe $(cat a.seed) > b.public_key
+  $ diff a.public_key b.public_key

--- a/test/iso.t
+++ b/test/iso.t
@@ -1,5 +1,5 @@
-  $ awa_gen_key > a.key
+  $ awa_gen_key --keytype rsa > a.key
   $ cat a.key | tail -n1 > a.public_key
-  $ cat a.key | head -n1 | cut -d' ' -f3 > a.seed
-  $ ./public_key_of_seed.exe rsa:$(cat a.seed) > b.public_key
+  $ cat a.key | head -n1 | cut -d' ' -f4 > a.seed
+  $ ./public_key_of_seed.exe $(cat a.seed) > b.public_key
   $ diff a.public_key b.public_key


### PR DESCRIPTION
This PR makes `awa_gen_key` output the key (seed) in the format expected of `Awa.Keys.of_string`.