### PR TITLE
client: support for password authentication fixes #31

### DIFF
--- a/lib/client.ml
+++ b/lib/client.ml
@@ -57,6 +57,10 @@ type gex_state =
   | Requested_gex of string * Ssh.kexinit * string * Ssh.kexinit * Kex.negotiation * int32 * int32 * int32
   | Negotiated_gex of string * Ssh.kexinit * string * Ssh.kexinit * Kex.negotiation * int32 * int32 * int32 * Z.t * Z.t * Mirage_crypto_pk.Dh.secret * Ssh.mpint
 
+type userauth_interactive =
+  | Requested of string
+  | Info_sent
+
 type state =
   | Init of string * Ssh.kexinit
   | Received_version of string * Ssh.kexinit * string
@@ -65,8 +69,10 @@ type state =
   | Gex of gex_state
   | Newkeys_before_auth of Kex.keys * Kex.keys
   | Requested_service of string
-  | Userauth_request of Ssh.auth_method
-  | Userauth_requested of Hostkey.pub option
+  | Userauth_initial
+  | Userauth_password
+  | Userauth_publickey of Hostkey.priv
+  | Userauth_keyboard_interactive of userauth_interactive
   | Opening_channel of Channel.channel_end
   | Established
 
@@ -255,36 +261,40 @@ let handle_newkeys_before_auth t keys =
 
 let service_accepted t = function
   | "ssh-userauth" ->
-    Ok ({ t with state = Userauth_request Authnone },
+    Ok ({ t with state = Userauth_initial },
         [ Ssh.Msg_userauth_request (t.user, service, Authnone) ],
         [])
   | service -> Error ("unknown service: " ^ service)
 
-let handle_auth_failure t _ = function
+let handle_auth_none t = function
   | [] -> Error "no authentication method left"
   | xs ->
     if t.auth_tried then
       Error "authentication failure"
     else
-      let* met =
-        match t.auth_method with
-        | `Pubkey key ->
-          if List.mem "publickey" xs then
-            let pub = Hostkey.pub_of_priv key in
-            Ok (Ssh.Pubkey (pub, None))
-          else
-            Error "no supported authentication methods left"
-        | `Password pass ->
-          if List.mem "password" xs then
-            Ok (Ssh.Password (pass, None))
-          else
-            Error "no supported authentication methods left"
-      in
-      Ok ({ t with state = Userauth_request met ; auth_tried = true },
-          [ Ssh.Msg_userauth_request (t.user, service, met) ],
-          [])
+      let auth_req met = [ Ssh.Msg_userauth_request (t.user, service, met) ] in
+      match t.auth_method with
+      | `Pubkey key ->
+        if List.mem "publickey" xs then
+          let pub = Hostkey.pub_of_priv key in
+          let met = Ssh.Pubkey (pub, None) in
+          Ok ({ t with state = Userauth_publickey key ; auth_tried = true },
+              auth_req met, [])
+        else
+          Error "no supported authentication methods left"
+      | `Password pass ->
+        if List.mem "password" xs then
+          let met = Ssh.Password (pass, None) in
+          Ok ({ t with state = Userauth_password ; auth_tried = true },
+              auth_req met, [])
+        else if List.mem "keyboard-interactive" xs then
+          let met = Ssh.Keyboard_interactive (None, []) in
+          let state = Userauth_keyboard_interactive (Requested pass) in
+          Ok ({ t with state ; auth_tried = true }, auth_req met, [])
+        else
+          Error "no supported authentication methods left"
 
-let handle_pk_auth t pk key =
+let handle_pk_auth t key =
   let session_id = match t.session_id with None -> assert false | Some x -> x in
   let* alg, sig_algs =
     match t.sig_algs with
@@ -293,19 +303,20 @@ let handle_pk_auth t pk key =
   in
   let signed = Auth.sign t.user alg key session_id service in
   let met = Ssh.Pubkey (Hostkey.pub_of_priv key, Some (alg, signed)) in
-  Ok ({ t with state = Userauth_requested (Some pk) ; sig_algs },
+  Ok ({ t with state = Userauth_publickey key ; sig_algs },
       [ Ssh.Msg_userauth_request (t.user, service, met) ],
       [])
 
-let handle_pk_fail t pk =
-  (* called when the signature algorithm wasn't received well by the server *)
-  match t.auth_method with
-  | `Pubkey key -> handle_pk_auth t pk key
-  | _ -> Error "not sure how we ended in pk fail now"
-
-let handle_pk_ok t m pk = match t.auth_method, m with
-  | `Pubkey key, Ssh.Pubkey (pub, None) when pub = pk -> handle_pk_auth t pk key
-  | _ -> Error "not sure how we ended in pk ok now"
+let handle_userauth_info_req t password (name, instruction, lang, prompts) =
+  Log.info (fun m -> m "keyboard interactive: name %s instruction %s lang %s"
+               name instruction lang);
+  List.iter (fun (prompt, _echo) -> Log.info (fun m -> m "PROMPT: %s" prompt))
+    prompts;
+  match prompts with
+  | [ _ ] ->
+    Ok ({ t with state = Userauth_keyboard_interactive Info_sent },
+        [ Ssh.Msg_userauth_info_response [ password ] ], [])
+  | _ -> Error "keyboard interactive user authentication: not a single prompt"
 
 let open_channel t =
   if Channel.is_empty t.channels then
@@ -382,16 +393,47 @@ let input_msg t msg now =
     handle_newkeys_before_auth t keys
   | Requested_service s, Msg_service_accept s' when s = s' ->
     service_accepted t s
-  | Userauth_request m, Msg_userauth_failure (methods, _) ->
-    handle_auth_failure t m methods
-  | Userauth_request m, Msg_userauth_pk_ok pk -> handle_pk_ok t m pk
-  | Userauth_requested (Some pk), Msg_userauth_failure _ -> handle_pk_fail t pk
-  | Userauth_request _, Msg_userauth_success -> open_channel t
-  | Userauth_requested _, Msg_userauth_success -> open_channel t
-  | (Userauth_request _ | Userauth_requested _), Msg_userauth_banner (banner, lang) ->
+  | Userauth_initial, Msg_userauth_failure (methods, _) ->
+    handle_auth_none t methods
+  | Userauth_publickey key, Msg_userauth_failure _ ->
+    (* signature algorithm wasn't received well by the server *)
+    handle_pk_auth t key
+  | Userauth_publickey key, Msg_userauth_1 buf ->
+    begin
+      let* m = Wire.userauth_pk_ok buf in
+      match m with
+      | Msg_userauth_pk_ok pub ->
+        if Hostkey.pub_of_priv key = pub then
+          handle_pk_auth t key
+        else
+          Error "key user authentication: public key does not match private"
+      | _ -> Error "unexpected userauth message"
+    end
+  | Userauth_keyboard_interactive (Requested password), Msg_userauth_1 buf ->
+    begin
+      let* m = Wire.userauth_info_request buf in
+      match m with
+      | Msg_userauth_info_request (n, i, l, p) ->
+        handle_userauth_info_req t password (n, i, l, p)
+      | _ -> Error "unexpected userauth message"
+    end
+  | Userauth_keyboard_interactive Info_sent, Msg_userauth_1 buf ->
+    begin
+      (* in contrast to 4256, OpenSSH sends another Info_req with no prompts *)
+      let* m = Wire.userauth_info_request buf in
+      match m with
+      | Msg_userauth_info_request (_, _, _, []) ->
+        Ok (t, [ Ssh.Msg_userauth_info_response [] ], [])
+      | _ -> Error "unexpected userauth message"
+    end
+  | (Userauth_password | Userauth_publickey _ | Userauth_keyboard_interactive _), Msg_userauth_success ->
+    open_channel t
+  | (Userauth_password | Userauth_publickey _ | Userauth_keyboard_interactive _), Msg_userauth_banner (banner, lang) ->
     Log.info (fun m -> m "userauth banner %s%s" banner
                  (if lang = "" then "" else " (lang " ^ lang ^ ")"));
     Ok (t, [], [])
+  | (Userauth_password | Userauth_keyboard_interactive _), Msg_userauth_failure _ ->
+    Error "user authentication failed"
   | Opening_channel us, Msg_channel_open_confirmation (oid, tid, win, max, data) ->
     open_channel_success t us oid tid win max data
   | _, Msg_global_request (_, want_reply, Unknown_request _) ->

--- a/lib/client.ml
+++ b/lib/client.ml
@@ -388,6 +388,10 @@ let input_msg t msg now =
   | Userauth_requested (Some pk), Msg_userauth_failure _ -> handle_pk_fail t pk
   | Userauth_request _, Msg_userauth_success -> open_channel t
   | Userauth_requested _, Msg_userauth_success -> open_channel t
+  | (Userauth_request _ | Userauth_requested _), Msg_userauth_banner (banner, lang) ->
+    Log.info (fun m -> m "userauth banner %s%s" banner
+                 (if lang = "" then "" else " (lang " ^ lang ^ ")"));
+    Ok (t, [], [])
   | Opening_channel us, Msg_channel_open_confirmation (oid, tid, win, max, data) ->
     open_channel_success t us oid tid win max data
   | _, Msg_global_request (_, want_reply, Unknown_request _) ->

--- a/lib/client.mli
+++ b/lib/client.mli
@@ -16,8 +16,8 @@
 
 type t
 
-val make : ?authenticator:Keys.authenticator -> user:string -> Hostkey.priv ->
-  t * Cstruct.t list
+val make : ?authenticator:Keys.authenticator -> user:string ->
+  [ `Pubkey of Hostkey.priv | `Password of string ] -> t * Cstruct.t list
 
 type event = [
   | `Established of int32

--- a/lib/server.ml
+++ b/lib/server.ml
@@ -179,8 +179,8 @@ let rec input_userauth_request t username service auth_method =
       try_auth t (by_pubkey username alg pubkey session_id service signed t.user_db)
     | Password (password, None) ->    (* Password authentication *)
       try_auth t (by_password username password t.user_db)
-    (* Change of password, or Authnone won't be supported *)
-    | Password (_, Some _) | Authnone -> failure t
+    (* Change of password, or keyboard_interactive, or Authnone won't be supported *)
+    | Password (_, Some _) | Keyboard_interactive _ | Authnone -> failure t
   in
   (* See if we can actually authenticate *)
   match t.auth_state with

--- a/lib/server.ml
+++ b/lib/server.ml
@@ -179,8 +179,8 @@ let rec input_userauth_request t username service auth_method =
       try_auth t (by_pubkey username alg pubkey session_id service signed t.user_db)
     | Password (password, None) ->    (* Password authentication *)
       try_auth t (by_password username password t.user_db)
-    (* Change of password, or Hostbased or Authnone won't be supported *)
-    | Password (_, Some _) | Hostbased _ | Authnone -> failure t
+    (* Change of password, or Authnone won't be supported *)
+    | Password (_, Some _) | Authnone -> failure t
   in
   (* See if we can actually authenticate *)
   match t.auth_state with

--- a/lib/ssh.ml
+++ b/lib/ssh.ml
@@ -172,7 +172,6 @@ let password_of_sexp _ = failwith "password_of_sexp: TODO"
 type auth_method =
   | Pubkey of (Hostkey.pub * (Hostkey.alg * Cstruct_sexp.t) option)
   | Password of (password * password option)
-  | Hostbased of (string * Cstruct_sexp.t * string * string * Cstruct_sexp.t) (* TODO *)
   | Authnone
 [@@deriving sexp]
 
@@ -187,11 +186,6 @@ let auth_method_equal a b =
     in
     key_a = key_b && signature_match
   | Password _, Password _ -> a = b
-  | Hostbased (key_alg_a, key_blob_a, hostname_a, hostuser_a, hostsig_a),
-    Hostbased (key_alg_b, key_blob_b, hostname_b, hostuser_b, hostsig_b) ->
-    key_alg_a = key_alg_b && (Cstruct.equal key_blob_a key_blob_b) &&
-    hostname_a = hostname_b && hostuser_a = hostuser_b &&
-    (Cstruct.equal hostsig_a hostsig_b)
   | Authnone, Authnone -> true
   | _ -> false
 

--- a/lib/wire.ml
+++ b/lib/wire.ml
@@ -408,13 +408,6 @@ let get_message buf =
         else
           let* password, buf = get_string buf in
           Ok (Password (password, None), buf)
-      | "hostbased" ->
-        let* key_alg, buf = get_string buf in
-        let* key_blob, buf = get_cstring buf in
-        let* hostname, buf = get_string buf in
-        let* hostuser, buf = get_string buf in
-        let* hostsig, buf = get_cstring buf in
-        Ok (Hostbased (key_alg, key_blob, hostname, hostuser, hostsig), buf)
       | "none" -> Ok (Authnone, buf)
       | _ -> Error ("Unknown method " ^ auth_method)
     in
@@ -740,13 +733,6 @@ let put_message msg buf =
           put_bool true buf |>
           put_string oldpassword |>
           put_string password)
-     | Hostbased (key_alg, key_blob, hostname, hostuser, hostsig) ->
-       put_string "hostbased" buf |>
-       put_string key_alg |>
-       put_cstring key_blob |>
-       put_string hostname |>
-       put_string hostuser |>
-       put_cstring hostsig
      | Authnone -> put_string "none" buf)
   | Msg_userauth_failure (nl, psucc) ->
     put_id MSG_USERAUTH_FAILURE buf |>

--- a/mirage/awa_mirage.ml
+++ b/mirage/awa_mirage.ml
@@ -137,9 +137,9 @@ module Make (F : Mirage_flow.S) (T : Mirage_time.S) (M : Mirage_clock.MCLOCK) = 
 
   let write t buf = writev t [buf]
 
-  let client_of_flow ?authenticator ~user key req flow =
+  let client_of_flow ?authenticator ~user auth req flow =
     let open Lwt_result.Infix in
-    let client, msgs = Awa.Client.make ?authenticator ~user key in
+    let client, msgs = Awa.Client.make ?authenticator ~user auth in
     let t = {
       flow   = flow ;
       state  = `Active client ;

--- a/mirage/awa_mirage.mli
+++ b/mirage/awa_mirage.mli
@@ -23,8 +23,8 @@ module Make (F : Mirage_flow.S) (T : Mirage_time.S) (M : Mirage_clock.MCLOCK) : 
       existing connection to SSH, mutually authenticates, opens a channel and
       sends the channel request. *)
   val client_of_flow : ?authenticator:Awa.Keys.authenticator -> user:string ->
-    Awa.Hostkey.priv -> Awa.Ssh.channel_request -> FLOW.flow ->
-    (flow, error) result Lwt.t
+    [ `Pubkey of Awa.Hostkey.priv | `Password of string ] ->
+    Awa.Ssh.channel_request -> FLOW.flow -> (flow, error) result Lwt.t
 
   type t
 

--- a/test/test.ml
+++ b/test/test.ml
@@ -216,10 +216,6 @@ let t_parsing () =
         ("haesbaert", "ssh-userauth",
          Password ("a", None));
       Msg_userauth_request
-        ("haesbaert", "ssh-userauth",
-         Hostbased ("a", (Cstruct.of_string "b"), "c", "d",
-                    (Cstruct.of_string "e")));
-      Msg_userauth_request
         ("haesbaert", "ssh-userauth", Authnone);
       Msg_userauth_failure (["Fora"; "Temer"], true);
       Msg_userauth_success;


### PR DESCRIPTION
This changes the API of Client.make (now receives a variant `Password of string | `Pubkey of key), and Awa_mirage.Make().client_of_flow as well.

This does not support the keyboard-interactive authentication mechanism (RFC 4256) that is commonly used (with e.g. PAM), but only the password authentication. May be useful for feature parity between server and client, and for some network devices.