### PR TITLE
Be able to stop the server via a `Lwt_switch.t`

### DIFF
--- a/mirage/awa_mirage.mli
+++ b/mirage/awa_mirage.mli
@@ -42,6 +42,26 @@ module Make (F : Mirage_flow.S) (T : Mirage_time.S) (M : Mirage_clock.MCLOCK) : 
 
   val spawn_server : ?stop:Lwt_switch.t -> Awa.Server.t -> Awa.Ssh.message list -> F.flow ->
     exec_callback -> t Lwt.t
+  (** [spawn_server ?stop server msgs flow callback] launches an {i internal}
+      SSH channels handler which can be stopped by [stop]. This SSH channels
+      handler will call [callback] for every new channels requested by the
+      client. [msgs] are the SSH {i hello} given by {!val:Awa.Server.make} which
+      returns also a {!type:Awa.Server.t} required here.
+
+      A basic usage of [spawn_server] is:
+      {[
+        let ssh_channel_handler _cmd _ic _oc _ec =
+          Lwt.return_unit
+
+        let tcp_handler flow =
+          let server, msgs = Awa.Server.make private_key db in
+          SSH.spawn_server server msgs flow ssh_handler >>= fun _t ->
+          close flow
+      ]}
+
+      {b NOTE}: Even if the [ssh_channel_handler] is fulfilled, [spawn_server]
+      continues to handle SSH channels. Only [stop] can really stop the internal
+      SSH channels handler. *)
 
 end
   with module FLOW = F

--- a/mirage/awa_mirage.mli
+++ b/mirage/awa_mirage.mli
@@ -40,7 +40,7 @@ module Make (F : Mirage_flow.S) (T : Mirage_time.S) (M : Mirage_clock.MCLOCK) : 
     (Cstruct.t -> unit Lwt.t) ->  (* ssherr *)
     unit Lwt.t
 
-  val spawn_server : Awa.Server.t -> Awa.Ssh.message list -> F.flow ->
+  val spawn_server : ?stop:Lwt_switch.t -> Awa.Server.t -> Awa.Ssh.message list -> F.flow ->
     exec_callback -> t Lwt.t
 
 end


### PR DESCRIPTION
This PR adds a new argument to the Awa_mirage.spawn_server. The switch permits to the user to stop the server by a simple Net_eof signal catched by the nexus (the main loop) function. It probably closes abruptely the connection

/cc @hannesm, @reynir