### PR TITLE
Add two events Pty/Set_env/Start_shell into the server

### DIFF
--- a/lib/wire.ml
+++ b/lib/wire.ml
@@ -40,7 +40,7 @@ let get_string buf =
   trap_error (fun () ->
       let len = Cstruct.BE.get_uint32 buf 0 |> Int32.to_int in
       Ssh.guard_sshlen_exn len;
-      (Cstruct.copy buf 4 len), Cstruct.shift buf (len + 4))
+      (Cstruct.to_string buf ~off:4 ~len), Cstruct.shift buf (len + 4))
 
 let put_string s t =
   let len = String.length s in

--- a/lwt/awa_lwt.ml
+++ b/lwt/awa_lwt.ml
@@ -157,6 +157,7 @@ let rec nexus t fd server input_buffer =
       let c = { cmd; id; sshin_mbox; exec_thread } in
       let t = { t with channels = c :: t.channels } in
       nexus t fd server input_buffer
+    | _ -> nexus t fd server input_buffer
 
 let spawn_server server msgs fd exec_callback =
   let t = { exec_callback;

--- a/test/awa_test_server.ml
+++ b/test/awa_test_server.ml
@@ -90,7 +90,7 @@ let rec serve t cmd =
   | Channel_subsystem (id, exec) (* same as exec *)
   | Channel_exec (id, exec) ->
     printf "channel exec %s\n%!" exec;
-    match exec with
+    begin match exec with
     | "suicide" ->
       let* _ = Driver.disconnect t in
       Ok ()
@@ -104,7 +104,8 @@ let rec serve t cmd =
       let* t = Driver.send_channel_data t id (Cstruct.of_string m) in
       printf "%s\n%!" m;
       let* t = Driver.disconnect t in
-      serve t cmd
+      serve t cmd end
+  | _ -> failwith "Invalid SSH event"
 
 let user_db =
   (* User foo auths by passoword *)


### PR DESCRIPTION
This PR change a bit the interface of `awa-mirage` and give the ability to handle new events:
- `Pty`: when the window change
- `Set_env`: when the client wants to set the local environment
- `Shell`: when the client requests a shell