### PR TITLE
Ext info implementation

### DIFF
--- a/awa.opam
+++ b/awa.opam
@@ -14,7 +14,7 @@ build: [
 ]
 
 depends: [
-  "ocaml" {>= "4.08.0"}
+  "ocaml" {>= "4.10.0"}
   "dune" {>= "2.7"}
   "mirage-crypto" {>= "0.8.1"}
   "mirage-crypto-rng" {>= "0.11.0"}

--- a/lib/kex.ml
+++ b/lib/kex.ml
@@ -116,10 +116,11 @@ let server_supported =
   [ Diffie_hellman_group14_sha256 ; Diffie_hellman_group14_sha1 ;
     Diffie_hellman_group1_sha1 ]
 
-let make_kexinit host_key_algs algs () =
+let make_kexinit ?ext_info host_key_algs algs () =
   let k =
     { cookie = Mirage_crypto_rng.generate 16;
       kex_algs = List.map alg_to_string algs;
+      ext_info;
       server_host_key_algs = List.map Hostkey.alg_to_string host_key_algs;
       encryption_algs_ctos = List.map Cipher.to_string Cipher.preferred;
       encryption_algs_stoc = List.map Cipher.to_string Cipher.preferred;

--- a/lib/server.ml
+++ b/lib/server.ml
@@ -32,6 +32,7 @@ type t = {
   client_kexinit : Ssh.kexinit option;    (* Last KEXINIT received *)
   server_kexinit : Ssh.kexinit;           (* Last KEXINIT sent by us *)
   neg_kex        : Kex.negotiation option;(* Negotiated KEX *)
+  ext_info       : bool;                  (* The other end wants ext_info *)
   host_key       : Hostkey.priv;          (* Server host key *)
   session_id     : Cstruct.t option;      (* First calculated H *)
   keys_ctos      : Kex.keys;              (* Client to server (input) keys *)
@@ -70,6 +71,7 @@ let make host_key user_db =
     server_kexinit;
     client_kexinit = None;
     neg_kex = None;
+    ext_info = false;
     host_key;
     session_id = None;
     keys_ctos = Kex.make_plaintext ();
@@ -294,7 +296,8 @@ let input_msg t msg now =
     let t = { t with client_kexinit = Some kex;
                      neg_kex = Some neg;
                      expect = Some MSG_KEX_0; (* TODO needs fix *)
-                     ignore_next_packet }
+                     ignore_next_packet;
+                     ext_info = kex.ext_info = Some `Ext_info_c; }
     in
     (match rekey t with
      | None -> make_noreply t   (* either already rekeying or not keyed *)
@@ -333,7 +336,18 @@ let input_msg t msg now =
                               new_keys_stoc = Some new_keys_stoc;
                               key_eol = Some key_eol;
                               expect = Some MSG_NEWKEYS }
-          [ Msg_kexdh_reply (pub_host_key, f, signature); Msg_newkeys ]
+          ([ Msg_kexdh_reply (pub_host_key, f, signature); Msg_newkeys ] @ (
+              if t.ext_info then
+                let preferred_algs =
+                  String.concat ","
+                    (List.map Hostkey.alg_to_string Hostkey.preferred_algs);
+                in
+                let extensions =
+                  [Extension { name = "server-sig-algs";
+                               value = preferred_algs; }]
+                in
+                [ Msg_ext_info extensions ]
+              else []))
       | _ ->
         Error "unexpected KEX message"
     end

--- a/lib/wire.ml
+++ b/lib/wire.ml
@@ -431,7 +431,6 @@ let get_message buf =
       | "publickey" ->
         let* has_sig, buf = get_bool buf in
         let* key_alg, buf = get_string buf in
-        Logs.warn (fun m -> m "read key_alg %S" key_alg);
         let* pubkey, buf = get_pubkey key_alg buf in
         if has_sig then
           let* key_sig = get_signature buf in


### PR DESCRIPTION
`SSH2_MSG_EXT_INFO` is a message type for communicating extensions. This PR implements parsing and serializing extension information messages. The server is as well extended to send the `server-sig-algs` extension with available signature algorithms. This is necessary for newer openssh clients that want to use RSA keys.

I am very open to changing the code as it was written somewhat in a hurry to get it working before a demo.