### PR TITLE
Handle unknown pubkeys

### DIFF
--- a/lib/keys.ml
+++ b/lib/keys.ml
@@ -71,7 +71,7 @@ let authenticator_of_string str =
     | _ ->
       match Base64.decode ~pad:false str with
       | Ok k ->
-        let* key = Wire.pubkey_of_blob (Cstruct.of_string k) in
+        let* key = Wire.pubkey_of_blob_error_as_string (Cstruct.of_string k) in
         Ok (`Key key)
       | Error (`Msg msg) ->
         Error (str ^ " is invalid or unsupported authenticator, b64 failed: " ^ msg)

--- a/lib/server.ml
+++ b/lib/server.ml
@@ -184,7 +184,7 @@ let rec input_userauth_request t username service auth_method =
     | Pubkey (_sig_alg_raw, pubkey_raw, None) -> (* Public key probing *)
       begin match Wire.pubkey_of_blob pubkey_raw with
         | Ok pubkey ->
-          (* TODO: match sig_alg and pubkey type *)
+          (* TODO: Hostkey.comptible_alg pubkey _sig_alg_raw *)
           try_probe t pubkey
         | Error `Unsupported keytype ->
           Logs.debug (fun m -> m "Client offered unsupported key type %s" keytype);
@@ -196,10 +196,11 @@ let rec input_userauth_request t username service auth_method =
     | Pubkey (_sig_alg_raw, pubkey_raw, Some (sig_alg, signed)) -> (* Public key authentication *)
       begin match Wire.pubkey_of_blob pubkey_raw with
         | Ok pubkey ->
-          (* TODO: match sig_alg and pubkey type *)
+          (* TODO: check equality of _sig_alg_raw and sig_alg? *)
+          (* TODO: Hostkey.comptible_alg pubkey _sig_alg_raw *)
           try_auth t (by_pubkey username sig_alg pubkey session_id service signed t.user_db)
         | Error `Unsupported keytype ->
-          Logs.debug (fun m -> m "Client attempted authentication with unsupported keytype %s" keytype);
+          Logs.debug (fun m -> m "Client attempted authentication with unsupported key type %s" keytype);
           failure t
         | Error `Msg s ->
           Logs.warn (fun m -> m "Failed to decode public key (while authenticating): %s" s);

--- a/test/test.ml
+++ b/test/test.ml
@@ -190,7 +190,9 @@ let t_parsing () =
   let rsa = Mirage_crypto_pk.Rsa.(generate ~bits:2048 ()) in
   let priv_rsa = Hostkey.Rsa_priv rsa in
   let pub_rsa = Hostkey.Rsa_pub (Mirage_crypto_pk.Rsa.pub_of_priv rsa) in
+  let pub_rsa_raw = Wire.blob_of_pubkey pub_rsa in
   let alg = Hostkey.Rsa_sha1 in
+  let alg_raw = Hostkey.alg_to_string alg in
   let signature = Hostkey.sign alg priv_rsa cstring in
   let l =
     [ Msg_disconnect (DISCONNECT_PROTOCOL_ERROR, "foo", "bar");
@@ -205,10 +207,10 @@ let t_parsing () =
       Msg_newkeys;
       Msg_userauth_request
         ("haesbaert", "ssh-userauth",
-         Pubkey (pub_rsa, None));
+         Pubkey (alg_raw, pub_rsa_raw, None));
       Msg_userauth_request
         ("haesbaert", "ssh-userauth",
-         Pubkey (pub_rsa, Some (alg, signature)));
+         Pubkey (alg_raw, pub_rsa_raw, Some (alg, signature)));
       Msg_userauth_request
         ("haesbaert", "ssh-userauth",
          Password ("a", Some "b"));


### PR DESCRIPTION
This PR delays parsing of public keys offered by clients. This allows clients to offer keys we don't know how to use to the server, and the server can reject them gracefully.

## Things to do
- [ ] Check the signature algorithm is compatible with the public key
- [ ] According to RFC 4252 the client MAY offer a signature without first probing the key. To implement this we need to further delay more parsing. I don't know how many clients behave this way, and as I've not encountered this behavior before we could defer implementing this to another PR.
- [ ] Figure out if we need to check the duplicated occurrences of signature algorithm and key type (the RFCs conflate both as "public key algorithm"). It may be helpful to look at what openssh does.