### PR TITLE
Fix test server

### DIFF
--- a/lib/server.ml
+++ b/lib/server.ml
@@ -30,6 +30,17 @@ type event =
   | Set_env of (string * string)
   | Start_shell of int32
 
+let pp_event ppf = function
+  | Channel_exec (c, cmd) -> Fmt.pf ppf "channel exec %lu: %S" c cmd
+  | Channel_subsystem (c, cmd) -> Fmt.pf ppf "channel subsystem %lu: %S" c cmd
+  | Channel_data (c, data) -> Fmt.pf ppf "channel data %lu: %d bytes" c (Cstruct.length data)
+  | Channel_eof c -> Fmt.pf ppf "channel end-of-file %lu" c
+  | Disconnected s -> Fmt.pf ppf "disconnected with messsage %S" s
+  | Pty _ -> Fmt.pf ppf "pty"
+  | Pty_set _ -> Fmt.pf ppf "pty set"
+  | Set_env (k, v) -> Fmt.pf ppf "Set env %S=%S" k v
+  | Start_shell c -> Fmt.pf ppf "start shell %lu" c
+
 type t = {
   client_version : string option;         (* Without crlf *)
   server_version : string;                (* Without crlf *)

--- a/test/awa_test_server.ml
+++ b/test/awa_test_server.ml
@@ -177,7 +177,23 @@ let rec serve t cmd =
       Logs.info (fun m -> m "%s" msg);
       let* t = Driver.disconnect t in
       serve t cmd end
-  | _ -> failwith "Invalid SSH event"
+  | Set_env (k, v) ->
+    Logs.info (fun m -> m "Ignoring Set_env (%S, %S)" k v);
+    serve t cmd
+  | Pty _ | Pty_set _ ->
+    let msg =
+      Ssh.disconnect_msg Ssh.DISCONNECT_SERVICE_NOT_AVAILABLE
+      "Sorry no PTY for you"
+    in
+    let* _ = Driver.send_msg t msg in
+    Ok ()
+  | Start_shell _ ->
+    let msg =
+      Ssh.disconnect_msg Ssh.DISCONNECT_SERVICE_NOT_AVAILABLE
+        "Sorry no shell for you"
+    in
+    let* _ = Driver.send_msg t msg in
+    Ok ()
 
 let user_db =
   (* User foo auths by passoword *)


### PR DESCRIPTION
Some time ago we added new events to the server, but we don't handle them in the test server.

This PR adds a pretty printer for the server events (currently unused), and adapts the awa test server to handle the new events by disconnecting the client with a message.