### PR TITLE
Refactor authentication, delay to effectful layer

### DIFF
--- a/lib/auth.ml
+++ b/lib/auth.ml
@@ -79,8 +79,8 @@ let verify db user userauth =
     verify_pubkeyauth ~user pubkeyauth && false
   | (None | Some { password = None; _ }), Password _ -> false
   | Some u, Pubkey pubkeyauth ->
-    (* XXX: polymorphic comparison *)
-    verify_pubkeyauth ~user pubkeyauth && List.mem pubkeyauth.pubkey u.keys
+    verify_pubkeyauth ~user pubkeyauth &&
+    List.exists (fun pubkey -> Hostkey.pub_eq pubkey pubkeyauth.pubkey) u.keys
   | Some { password = Some password; _ }, Password password' ->
       let open Digestif.SHA256 in
       let a = digest_string password

--- a/lib/auth.ml
+++ b/lib/auth.ml
@@ -71,9 +71,6 @@ let sign name alg key session_id service =
   let data = to_hash name alg (Hostkey.pub_of_priv key) session_id service in
   Hostkey.sign alg key data
 
-let by_pubkey name alg pubkey session_id service signed db =
-  match lookup_user_key name pubkey db with
-  | None -> false
-  | Some pubkey ->
-    let unsigned = to_hash name alg pubkey session_id service in
-    Hostkey.verify alg pubkey ~unsigned ~signed
+let by_pubkey name alg pubkey session_id service signed =
+  let unsigned = to_hash name alg pubkey session_id service in
+  Hostkey.verify alg pubkey ~unsigned ~signed

--- a/lib/server.ml
+++ b/lib/server.ml
@@ -19,7 +19,7 @@ open Util
 let src = Logs.Src.create "awa.server" ~doc:"AWA server"
 module Log = (val Logs.src_log src : Logs.LOG)
 
-type pubkeyauth = {
+type pubkeyauth = Auth.pubkeyauth = {
   pubkey : Hostkey.pub ;
   session_id : string ;
   service : string ;
@@ -27,12 +27,11 @@ type pubkeyauth = {
   signed : string ;
 }
 
-let pubkey_of_pubkeyauth { pubkey; _ } = pubkey
+let pubkey_of_pubkeyauth = Auth.pubkey_of_pubkeyauth
 
-let verify_pubkeyauth ~user { pubkey; session_id; service ; sig_alg ; signed } =
-  Auth.by_pubkey user sig_alg pubkey session_id service signed
+let verify_pubkeyauth = Auth.verify_pubkeyauth
 
-type userauth =
+type userauth = Auth.userauth =
   | Password of string
   | Pubkey of pubkeyauth
 

--- a/lib/server.ml
+++ b/lib/server.ml
@@ -19,7 +19,12 @@ open Util
 let src = Logs.Src.create "awa.server" ~doc:"AWA server"
 module Log = (val Logs.src_log src : Logs.LOG)
 
-type pubkeyauth = Auth.pubkeyauth = {
+type auth_state =
+  | Preauth
+  | Inprogress of (string * string * int)
+  | Done
+
+type pubkeyauth = {
   pubkey : Hostkey.pub ;
   session_id : string ;
   service : string ;
@@ -27,11 +32,12 @@ type pubkeyauth = Auth.pubkeyauth = {
   signed : string ;
 }
 
-let pubkey_of_pubkeyauth = Auth.pubkey_of_pubkeyauth
+let pubkey_of_pubkeyauth { pubkey; _ } = pubkey
 
-let verify_pubkeyauth = Auth.verify_pubkeyauth
+let verify_pubkeyauth ~user { pubkey; session_id; service ; sig_alg ; signed } =
+  Auth.verify_signature user sig_alg pubkey session_id service signed
 
-type userauth = Auth.userauth =
+type userauth =
   | Password of string
   | Pubkey of pubkeyauth
 
@@ -76,7 +82,7 @@ type t = {
   keying         : bool;                  (* keying = sent KEXINIT *)
   key_eol        : Mtime.t option;        (* Keys end of life, in ns *)
   expect         : Ssh.message_id option; (* Messages to expect, None if any *)
-  auth_state     : Auth.state;            (* username * service in progress *)
+  auth_state     : auth_state;            (* username * service in progress *)
   channels       : Channel.db;            (* Ssh channels *)
   ignore_next_packet : bool;              (* Ignore the next packet from the wire *)
   dh_group       : (Mirage_crypto_pk.Dh.group * int32 * int32 * int32) option; (* used for GEX (RFC 4419) *)
@@ -119,7 +125,7 @@ let make host_key =
     keying = true;
     key_eol = None;
     expect = Some MSG_VERSION;
-    auth_state = Auth.Preauth;
+    auth_state = Preauth;
     channels = Channel.empty_db;
     ignore_next_packet = false;
     dh_group = None;
@@ -185,7 +191,7 @@ let make_reply_with_event t msg e = Ok (t, [ msg ], Some e)
 let make_disconnect t code s =
   Ok (t, [ Ssh.disconnect_msg code s ], Some (Disconnected s))
 
-let rec input_userauth_request t username service auth_method =
+let input_userauth_request t username service auth_method =
   let open Ssh in
   let inc_nfailed t =
     match t.auth_state with
@@ -201,69 +207,72 @@ let rec input_userauth_request t username service auth_method =
     let* t = inc_nfailed t in
     make_reply t (Msg_userauth_failure ([ "publickey"; "password" ], false))
   in
-  let discard t = make_noreply t in
   let try_probe t pubkey =
     make_reply t (Msg_userauth_pk_ok pubkey)
   in
-  let handle_auth t =
-    (* XXX verify all fail cases, what should we do and so on *)
-    let* session_id = guard_some t.session_id "No session_id" in
-    let* () = guard (service = "ssh-connection") "Bad service" in
-    match auth_method with
-    | Pubkey (pkalg, pubkey_raw, None) -> (* Public key probing *)
-      begin match Wire.pubkey_of_blob pubkey_raw with
-        | Ok pubkey when Hostkey.comptible_alg pubkey pkalg ->
-          try_probe t pubkey
-        | Ok _ ->
+  (* XXX verify all fail cases, what should we do and so on *)
+  let* session_id = guard_some t.session_id "No session_id" in
+  let* () = guard (service = "ssh-connection") "Bad service" in
+  match auth_method with
+  | Pubkey (pkalg, pubkey_raw, None) -> (* Public key probing *)
+    begin match Wire.pubkey_of_blob pubkey_raw with
+      | Ok pubkey when Hostkey.comptible_alg pubkey pkalg ->
+        try_probe t pubkey
+      | Ok _ ->
+        Log.debug (fun m -> m "Client offered unsupported or incompatible signature algorithm %s"
+                      pkalg);
+        failure t
+      | Error `Unsupported keytype ->
+        Log.debug (fun m -> m "Client offered unsupported key type %s" keytype);
+        failure t
+      | Error `Msg s ->
+        Log.warn (fun m -> m "Failed to decode public key (while client offered a key): %s" s);
+        disconnect t DISCONNECT_PROTOCOL_ERROR "public key decoding failed"
+    end
+  | Pubkey (pkalg, pubkey_raw, Some (sig_alg, signed)) -> (* Public key authentication *)
+    begin match Wire.pubkey_of_blob pubkey_raw with
+      | Ok pubkey when Hostkey.comptible_alg pubkey pkalg &&
+                       String.equal pkalg sig_alg ->
+        (* NOTE: for backwards compatibility with older OpenSSH clients we
+           should be more lenient if the sig_alg is "ssh-rsa-cert-v01" (if we
+           ever implement that). See
+           https://github.com/openssh/openssh-portable/blob/master/ssh-rsa.c#L504-L507 *)
+        (* XXX: this should be fine due to the previous [Hostkey.comptible_alg] *)
+        (* TODO: avoid Result.get_ok :/ *)
+        let sig_alg = Result.get_ok (Hostkey.alg_of_string sig_alg) in
+        Ok (t, [], Some (Userauth (username, Pubkey { pubkey; session_id; service; sig_alg; signed })))
+      | Ok pubkey ->
+        if Hostkey.comptible_alg pubkey pkalg then
           Log.debug (fun m -> m "Client offered unsupported or incompatible signature algorithm %s"
-                        pkalg);
-          failure t
-        | Error `Unsupported keytype ->
-          Log.debug (fun m -> m "Client offered unsupported key type %s" keytype);
-          failure t
-        | Error `Msg s ->
-          Log.warn (fun m -> m "Failed to decode public key (while client offered a key): %s" s);
-          disconnect t DISCONNECT_PROTOCOL_ERROR "public key decoding failed"
-      end
-    | Pubkey (pkalg, pubkey_raw, Some (sig_alg, signed)) -> (* Public key authentication *)
-      begin match Wire.pubkey_of_blob pubkey_raw with
-        | Ok pubkey when Hostkey.comptible_alg pubkey pkalg &&
-                         String.equal pkalg sig_alg ->
-          (* NOTE: for backwards compatibility with older OpenSSH clients we
-             should be more lenient if the sig_alg is "ssh-rsa-cert-v01" (if we
-             ever implement that). See
-             https://github.com/openssh/openssh-portable/blob/master/ssh-rsa.c#L504-L507 *)
-          (* XXX: this should be fine due to the previous [Hostkey.comptible_alg] *)
-          (* TODO: avoid Result.get_ok :/ *)
-          let sig_alg = Result.get_ok (Hostkey.alg_of_string sig_alg) in
-          Ok (t, [], Some (Userauth (username, Pubkey { pubkey; session_id; service; sig_alg; signed })))
-        | Ok pubkey ->
-          if Hostkey.comptible_alg pubkey pkalg then
-            Log.debug (fun m -> m "Client offered unsupported or incompatible signature algorithm %s"
-                          pkalg)
-          else
-            Log.debug (fun m -> m "Client offered signature using algorithm different from advertised: %s vs %s"
-                          sig_alg pkalg);
-          failure t
-        | Error `Unsupported keytype ->
-          Log.debug (fun m -> m "Client attempted authentication with unsupported key type %s" keytype);
-          failure t
-        | Error `Msg s ->
-          Log.warn (fun m -> m "Failed to decode public key (while authenticating): %s" s);
-          disconnect t DISCONNECT_PROTOCOL_ERROR "public key decoding failed"
-      end
-    | Password (password, None) -> (* Password authentication *)
-      Ok (t, [], Some (Userauth (username, Password password)))
-    (* Change of password, or keyboard_interactive, or Authnone won't be supported *)
-    | Password (_, Some _) | Keyboard_interactive _ | Authnone -> failure t
-  in
+                        pkalg)
+        else
+          Log.debug (fun m -> m "Client offered signature using algorithm different from advertised: %s vs %s"
+                        sig_alg pkalg);
+        failure t
+      | Error `Unsupported keytype ->
+        Log.debug (fun m -> m "Client attempted authentication with unsupported key type %s" keytype);
+        failure t
+      | Error `Msg s ->
+        Log.warn (fun m -> m "Failed to decode public key (while authenticating): %s" s);
+        disconnect t DISCONNECT_PROTOCOL_ERROR "public key decoding failed"
+    end
+  | Password (password, None) -> (* Password authentication *)
+    Ok (t, [], Some (Userauth (username, Password password)))
+  (* Change of password, or keyboard_interactive, or Authnone won't be supported *)
+  | Password (_, Some _) | Keyboard_interactive _ | Authnone -> failure t
+
+let input_userauth_request t username service auth_method =
   (* See if we can actually authenticate *)
   match t.auth_state with
-  | Auth.Done -> discard t (* RFC tells us we must discard requests if already authenticated *)
-  | Auth.Preauth -> (* Recurse, but now Inprogress *)
-    let t = { t with auth_state = Auth.Inprogress (username, service, 0) } in
+  | Done -> make_noreply t (* RFC tells us we must discard requests if already authenticated *)
+  | Preauth -> (* Recurse, but now Inprogress *)
+    let t = { t with auth_state = Inprogress (username, service, 0) } in
     input_userauth_request t username service auth_method
   | Inprogress (prev_username, prev_service, nfailed) ->
+    let disconnect t code s =
+      let t = { t with auth_state = Inprogress (prev_username, prev_service, succ nfailed) } in
+      make_disconnect t code s
+    in
     if service <> "ssh-connection" then
       disconnect t DISCONNECT_SERVICE_NOT_AVAILABLE
         (sprintf "Don't know service `%s`" service)
@@ -276,22 +285,22 @@ let rec input_userauth_request t username service auth_method =
     else if nfailed > 10 then
       Error "Maximum authentication attempts reached, already sent disconnect"
     else
-      handle_auth t
+      input_userauth_request t username service auth_method
 
 let reject_userauth t _userauth =
   match t.auth_state with
-  | Auth.Inprogress (u, s, nfailed) ->
-    let t = { t with auth_state = Auth.Inprogress (u, s, succ nfailed) } in
+  | Inprogress (u, s, nfailed) ->
+    let t = { t with auth_state = Inprogress (u, s, succ nfailed) } in
     Ok (t, Ssh.Msg_userauth_failure ([ "publickey"; "password" ], false))
-  | Auth.Done | Auth.Preauth ->
+  | Done | Preauth ->
     Error "userauth in unexpected state"
 
 let accept_userauth t _userauth =
   match t.auth_state with
-  | Auth.Inprogress _ ->
-    let t = { t with auth_state = Auth.Done; expect = None } in
+  | Inprogress _ ->
+    let t = { t with auth_state = Done; expect = None } in
     Ok (t, Ssh.Msg_userauth_success)
-  | Auth.Done | Auth.Preauth ->
+  | Done | Preauth ->
     Error "userauth in unexpected state"
 
 let input_channel_open t send_channel init_win_size max_pkt_size data =

--- a/lib/server.ml
+++ b/lib/server.ml
@@ -78,7 +78,6 @@ type t = {
   key_eol        : Mtime.t option;        (* Keys end of life, in ns *)
   expect         : Ssh.message_id option; (* Messages to expect, None if any *)
   auth_state     : Auth.state;            (* username * service in progress *)
-  user_db        : Auth.db;               (* username database *)
   channels       : Channel.db;            (* Ssh channels *)
   ignore_next_packet : bool;              (* Ignore the next packet from the wire *)
   dh_group       : (Mirage_crypto_pk.Dh.group * int32 * int32 * int32) option; (* used for GEX (RFC 4419) *)
@@ -98,7 +97,7 @@ let guard_msg t msg =
 let host_key_algs key =
   List.filter Hostkey.(alg_matches (priv_to_typ key)) Hostkey.preferred_algs
 
-let make host_key user_db =
+let make host_key =
   let open Ssh in
   let server_kexinit =
     let algs = host_key_algs host_key in
@@ -122,7 +121,6 @@ let make host_key user_db =
     key_eol = None;
     expect = Some MSG_VERSION;
     auth_state = Auth.Preauth;
-    user_db;
     channels = Channel.empty_db;
     ignore_next_packet = false;
     dh_group = None;

--- a/mirage/awa_mirage.ml
+++ b/mirage/awa_mirage.ml
@@ -390,7 +390,7 @@ module Make (F : Mirage_flow.S) = struct
       | None -> nexus t fd server input_buffer (List.append pending_promises [ Lwt_mvar.take t.nexus_mbox ])
       | Some Awa.Server.Userauth (user, userauth) ->
         let accept = Auth.verify t.user_db user userauth in
-        (* FIXME: Result.get_ok *)
+        (* FIXME: Result.get_ok: Awa.Server.{accept,reject}_userauth should likely raise instead *)
         let server, reply =
           Result.get_ok
             (if accept then

--- a/mirage/awa_mirage.ml
+++ b/mirage/awa_mirage.ml
@@ -357,19 +357,7 @@ module Make (F : Mirage_flow.S) = struct
       match event with
       | None -> nexus t fd server input_buffer (List.append pending_promises [ Lwt_mvar.take t.nexus_mbox ])
       | Some Awa.Server.Userauth (user, userauth) ->
-        let accept =
-          match Awa.Auth.lookup_user user t.user_db with
-          | None ->
-            false
-          | Some u ->
-            match userauth with
-            | Password password ->
-              u.password = Some password
-            | Pubkey pubkeyauth ->
-              Awa.Server.verify_pubkeyauth ~user pubkeyauth &&
-              (* XXX: polymorphic compare *)
-              List.mem (Awa.Server.pubkey_of_pubkeyauth pubkeyauth) u.keys
-        in
+        let accept = Awa.Auth.verify t.user_db user userauth in
         (* FIXME: Result.get_ok *)
         let server, reply =
           Result.get_ok

--- a/mirage/awa_mirage.mli
+++ b/mirage/awa_mirage.mli
@@ -40,7 +40,7 @@ module Make (F : Mirage_flow.S) : sig
 
   type exec_callback = request -> unit Lwt.t
 
-  val spawn_server : ?stop:Lwt_switch.t -> Awa.Server.t -> Awa.Ssh.message list -> F.flow ->
+  val spawn_server : ?stop:Lwt_switch.t -> Awa.Server.t -> Awa.Auth.db -> Awa.Ssh.message list -> F.flow ->
     exec_callback -> t Lwt.t
   (** [spawn_server ?stop server msgs flow callback] launches an {i internal}
       SSH channels handler which can be stopped by [stop]. This SSH channels

--- a/mirage/awa_mirage.mli
+++ b/mirage/awa_mirage.mli
@@ -1,5 +1,12 @@
 (** Effectful operations using Mirage for pure SSH. *)
 
+module Auth : sig
+  type user
+  type db = user list
+
+  val make_user : string -> ?password:string -> Awa.Hostkey.pub list -> user
+end
+
 (** SSH module given a flow *)
 module Make (F : Mirage_flow.S) : sig
 
@@ -40,7 +47,7 @@ module Make (F : Mirage_flow.S) : sig
 
   type exec_callback = request -> unit Lwt.t
 
-  val spawn_server : ?stop:Lwt_switch.t -> Awa.Server.t -> Awa.Auth.db -> Awa.Ssh.message list -> F.flow ->
+  val spawn_server : ?stop:Lwt_switch.t -> Awa.Server.t -> Auth.db -> Awa.Ssh.message list -> F.flow ->
     exec_callback -> t Lwt.t
   (** [spawn_server ?stop server msgs flow callback] launches an {i internal}
       SSH channels handler which can be stopped by [stop]. This SSH channels

--- a/test/test.ml
+++ b/test/test.ml
@@ -335,7 +335,7 @@ let t_mpint () =
   test_ok
 
 let t_version () =
-  let t, _ = Server.make (Hostkey.Rsa_priv (Mirage_crypto_pk.Rsa.generate ~bits:2048 ())) [] in
+  let t, _ = Server.make (Hostkey.Rsa_priv (Mirage_crypto_pk.Rsa.generate ~bits:2048 ())) in
   let client_version = "SSH-2.0-OpenSSH_6.9\r\n" in
   let* t, msg, input_buffer =
     Server.pop_msg2 t (Cstruct.of_string client_version)
@@ -410,7 +410,7 @@ let t_signature () =
   test_ok
 
 let t_ignore_next_packet () =
-  let t, _ = Server.make (Hostkey.Rsa_priv (Mirage_crypto_pk.Rsa.generate ~bits:2048 ())) [] in
+  let t, _ = Server.make (Hostkey.Rsa_priv (Mirage_crypto_pk.Rsa.generate ~bits:2048 ())) in
   let t = Server.{ t with client_version = Some "SSH-2.0-client";
                           expect = Some(Ssh.MSG_KEXINIT) }
   in


### PR DESCRIPTION
Userauth is now an event. This means the effectful layer can do e.g. database lookups or LDAP requests when authenticating a user.

As an added bonus an effectful layer that implements trust on first use (TOFU) user authentication is now possible (like banawa-ssh used in banawa-chat).

I also generated .mli files auth.mli and server.mli that I can commit. There I make `Awa.Server.userauth`s constructors private, and `Awa.Server.pubkeyauth` is opaque.

~~TODO is updating the tests / awa_test_server.~~