### PR TITLE
Fix regression from 6379b473

### DIFF
--- a/lib/server.ml
+++ b/lib/server.ml
@@ -372,7 +372,7 @@ let input_msg t msg now =
       if t.ext_info then
         let algs =
           String.concat ","
-            (List.map Hostkey.alg_to_string (host_key_algs t.host_key));
+            (List.map Hostkey.alg_to_string Hostkey.preferred_algs);
         in
         let extensions =
           [Extension { name = "server-sig-algs"; value = algs; }]


### PR DESCRIPTION
The server-sig-algs should be Hostkey.preferred_algs, not just the algorithm for the servers host key. That way we can have a server that uses a ed25519 host key and allow authentication with an RSA key.

Found while testing #74 using awa_test_server.