### PR TITLE
Fixed [msg_channel_data] buffering and size issues.

### DIFF
--- a/lib/channel.ml
+++ b/lib/channel.ml
@@ -75,8 +75,8 @@ let input_data t data =
   in
   Ok (t, data, msg)
 
-let output_data t data =
-  let fragment data =
+let output_data ?(flush = false) t data =
+  let fragment acc data =
     let max_pkt = Int32.to_int t.them.max_pkt in
     let i =
       Cstruct.iter
@@ -90,15 +90,26 @@ let output_data t data =
     in
     Cstruct.fold (fun frags frag ->
         Ssh.Msg_channel_data (t.them.id, frag) :: frags)
-      i [] |> List.rev
+      i acc |> List.rev
   in
   let tosend = cs_join t.tosend data in
   let len = min (Cstruct.length tosend) (Int32.to_int t.them.win) in
-  let data, tosend = Cstruct.split tosend len in
+  let data, tosend =
+    if flush then
+      tosend, Cstruct.create 0
+    else
+      Cstruct.split tosend len in
   let win = Int32.sub t.them.win (Int32.of_int len) in
   let* () = guard Int32.(win >= zero) "window underflow" in
   let t = { t with tosend; them = { t.them with win } } in
-  Ok (t, fragment data)
+  let adjust_window =
+    Ssh.Msg_channel_window_adjust (t.them.id, Int32.of_int len) in
+  Ok (t, fragment [adjust_window] data)
+
+let flush t =
+  let data = t.tosend in
+  let t = { t with tosend = Cstruct.create 0 } in
+  output_data ~flush: true t data
 
 let adjust_window t len =
   let win = Int32.add t.them.win len in
@@ -106,7 +117,7 @@ let adjust_window t len =
   let* () = guard Int32.(win > zero) "window overflow" in
   let data = t.tosend in
   let t = { t with tosend = Cstruct.create 0; them = { t.them with win } } in
-  output_data t data
+  output_data ~flush: true t data
 
 (*
  * Channel database

--- a/lib/client.ml
+++ b/lib/client.ml
@@ -520,7 +520,7 @@ let outgoing_data t ?(id = 0l) data =
   let* () = guard (established t) "not yet established" in
   let* () = guard (Cstruct.length data > 0) "empty data" in
   let* c = guard_some (Channel.lookup id t.channels) "no such channel" in
-  let* c, frags = Channel.output_data c data in
+  let* c, frags = Channel.output_data ~flush:false c data in
   let t' = { t with channels = Channel.update c t.channels } in
   Ok (output_msgs t' frags)
 

--- a/lib/client.ml
+++ b/lib/client.ml
@@ -528,11 +528,13 @@ let eof ?(id = 0l) t =
   match
     let* () = guard (established t) "not yet established" in
     let* c = guard_some (Channel.lookup id t.channels) "no such channel" in
+    let* c, frags = Channel.flush c in
+    let t' = { t with channels = Channel.update c t.channels } in
     let msg = Ssh.Msg_channel_eof c.them.id in
-    Ok (output_msg t msg)
+    Ok (output_msgs t' (List.append frags [msg]))
   with
-  | Error _ -> t, None
-  | Ok (t, msg) -> t, Some msg
+  | Error _ -> t, []
+  | Ok (t, msgs) -> t, msgs
 
 let close ?(id = 0l) t =
   match

--- a/lib/client.mli
+++ b/lib/client.mli
@@ -39,6 +39,6 @@ val outgoing_request : t -> ?id:int32 -> ?want_reply:bool ->
 val outgoing_data : t -> ?id:int32 -> Cstruct.t ->
   (t * Cstruct.t list, string) result
 
-val eof : ?id:int32 -> t -> t * Cstruct.t option
+val eof : ?id:int32 -> t -> t * Cstruct.t list
 
 val close : ?id:int32 -> t -> t * Cstruct.t option

--- a/lib/server.ml
+++ b/lib/server.ml
@@ -563,5 +563,5 @@ let output_msg t msg =
 let output_channel_data t id data =
   let* () = guard (Cstruct.length data > 0) "empty data" in
   let* c = guard_some (Channel.lookup id t.channels) "no such channel" in
-  let* c, frags = Channel.output_data c data in
+  let* c, frags = Channel.output_data ~flush:false c data in
   Ok ({ t with channels = Channel.update c t.channels }, frags)

--- a/test/test.ml
+++ b/test/test.ml
@@ -479,7 +479,7 @@ let t_channel_output () =
   in
   (* Case 1: Small output, single message *)
   let d' = Cstruct.sub d 0 32 in
-  let* c', msgs' = Channel.output_data c d' in
+  let* c', msgs' = Channel.output_data ~flush:false c d' in
   assert ((List.length msgs') = 1);
   let msg' = List.hd msgs' in
   let* () =
@@ -497,7 +497,7 @@ let t_channel_output () =
   (* Make sure we didn't change defaults *)
   assert ((Int32.to_int Channel.(c.them.max_pkt)) = (64 * 1024));
   let d' = Cstruct.sub d 0 (96 * 1024) in
-  let* _c', msgs' = Channel.output_data c d' in
+  let* _c', msgs' = Channel.output_data ~flush:false c d' in
   assert ((List.length msgs') = 2);
   let msg1' = List.nth msgs' 0 in
   let msg2' = List.nth msgs' 1 in
@@ -520,7 +520,7 @@ let t_channel_output () =
     | _ -> Error "unexpected msg2'"
   in
   (* Case 3: See if peer window is respected, one byte will be outside the window *)
-  let* c', msgs' = Channel.output_data c d in
+  let* c', msgs' = Channel.output_data ~flush:false c d in
   let exp_nmsgs' = 1 + Cstruct.length d / Int32.to_int Ssh.channel_max_pkt_len in
   (* printf "exp_nmsgs = %d (%d/%d) l=%d\n%!"
    *   exp_nmsgs'


### PR DESCRIPTION
Before [msg_channel_eof] was sent without draining [channel.tosent] buffer. Also sending large amount of data using [msg_channel_data] was not possible since no [msg_channel_window_adjust] was issued.

Now [Client.eof] flushes channel buffer. And [Client.outgoing_data] issues [msg_channel_window_adjust] before sending data.