### PR TITLE
Add authentication information to auth Done state

### DIFF
--- a/mirage/awa_mirage.ml
+++ b/mirage/awa_mirage.ml
@@ -394,7 +394,7 @@ module Make (F : Mirage_flow.S) = struct
         let server, reply =
           Result.get_ok
             (if accept then
-               Awa.Server.accept_userauth server userauth
+               Awa.Server.accept_userauth server userauth ()
              else
                Awa.Server.reject_userauth server userauth)
         in

--- a/mirage/awa_mirage.mli
+++ b/mirage/awa_mirage.mli
@@ -47,7 +47,7 @@ module Make (F : Mirage_flow.S) : sig
 
   type exec_callback = request -> unit Lwt.t
 
-  val spawn_server : ?stop:Lwt_switch.t -> Awa.Server.t -> Auth.db -> Awa.Ssh.message list -> F.flow ->
+  val spawn_server : ?stop:Lwt_switch.t -> unit Awa.Server.t -> Auth.db -> Awa.Ssh.message list -> F.flow ->
     exec_callback -> t Lwt.t
   (** [spawn_server ?stop server msgs flow callback] launches an {i internal}
       SSH channels handler which can be stopped by [stop]. This SSH channels

--- a/test/awa_test_server.ml
+++ b/test/awa_test_server.ml
@@ -26,7 +26,7 @@ module Driver = struct
  *)
 
   type t = {
-    server         : Server.t;            (* Underlying server *)
+    server         : unit Server.t;       (* Underlying server *)
     input_buffer   : Cstruct.t;           (* Unprocessed input *)
     write_cb       : Cstruct.t -> unit;   (* Blocking write callback *)
     read_cb        : unit -> Cstruct.t;   (* Blocking read callback *)
@@ -82,7 +82,7 @@ module Driver = struct
   let user_auth t userauth success =
     let* server, reply =
       if success then
-        Awa.Server.accept_userauth t.server userauth
+        Awa.Server.accept_userauth t.server userauth ()
       else
         Awa.Server.reject_userauth t.server userauth
     in


### PR DESCRIPTION
Useful for keeping information such as what username was authenticated with, or what public key was used.