### PR TITLE
make lookup_user public

### DIFF
--- a/mirage/awa_mirage.mli
+++ b/mirage/awa_mirage.mli
@@ -5,6 +5,7 @@ module Auth : sig
   type db = user list
 
   val make_user : string -> ?password:string -> Awa.Hostkey.pub list -> user
+  val lookup_user : string -> db -> user option
 end
 
 (** SSH module given a flow *)


### PR DESCRIPTION
This PR wants to add the ability to check the presence of an existing user in the user database.
Before the Auth refactoring, I could call `Awa.Auth.lookup_user user db`, but not anymore. With this PR I'm able to call `Awa_mirage.Auth.lookup_user` again :)
The other solution, if there is another path to check that, is to change my code, but I haven't figured out yet.
I don't know if, while I'm at it, I should also make verify public, so you can tell me :) 
Best